### PR TITLE
Allow headless builds without system SDL3 libraries

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,34 @@ import Foundation
 let env = ProcessInfo.processInfo.environment
 let useYams = (env["SDLKIT_NO_YAMS"] ?? "0") != "1"
 
+func pkgConfigExists(_ package: String) -> Bool {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["pkg-config", "--exists", package]
+    process.standardOutput = Pipe()
+    process.standardError = Pipe()
+    do {
+        try process.run()
+        process.waitUntilExit()
+        return process.terminationStatus == 0
+    } catch {
+        return false
+    }
+}
+
+let forceStub = (env["SDLKIT_FORCE_HEADLESS"] ?? "0") == "1"
+let forceSystem = (env["SDLKIT_FORCE_SYSTEM_SDL"] ?? "0") == "1"
+
+func shouldUseSystemPackage(_ pkg: String) -> Bool {
+    if forceStub { return false }
+    if forceSystem { return true }
+    return pkgConfigExists(pkg)
+}
+
+let hasSDL3 = shouldUseSystemPackage("sdl3")
+let hasSDL3Image = shouldUseSystemPackage("sdl3-image")
+let hasSDL3TTF = shouldUseSystemPackage("sdl3-ttf")
+
 let package = Package(
     name: "SDLKit",
     platforms: [
@@ -21,77 +49,131 @@ let package = Package(
         }
         return deps
     }(),
-    targets: [
-        .systemLibrary(
-            name: "CSDL3",
-            pkgConfig: "sdl3",
-            providers: [
-                .brew(["sdl3"]),
-                .apt(["libsdl3-dev"])
-            ]
-        ),
-        .systemLibrary(
-            name: "CSDL3IMAGE",
-            pkgConfig: "sdl3-image",
-            providers: [
-                .brew(["sdl3_image"]),
-                .apt(["libsdl3-image-dev"])
-            ]
-        ),
-        .systemLibrary(
-            name: "CSDL3TTF",
-            pkgConfig: "sdl3-ttf",
-            providers: [
-                .brew(["sdl3_ttf"]),
-                .apt(["libsdl3-ttf-dev"])
-            ]
-        ),
-        .target(
-            name: "SDLKit",
-            dependencies: {
-                var deps: [Target.Dependency] = [
-                    "CSDL3",
-                    .target(name: "CSDL3IMAGE", condition: .when(platforms: [.macOS, .linux]))
-                ]
-                if useYams { deps.append(.product(name: "Yams", package: "Yams")) }
-                return deps
-            }(),
-            path: "Sources/SDLKit",
-            cSettings: {
-                var flags: [CSetting] = []
-                if let inc = env["SDL3_INCLUDE_DIR"], !inc.isEmpty {
-                    flags.append(.unsafeFlags(["-I\(inc)"]))
-                }
-                // Fallback common include roots
-                flags.append(.unsafeFlags(["-I/usr/local/include"]))
-                flags.append(.unsafeFlags(["-I/usr/include"]))
-                return flags
-            }(),
-            swiftSettings: useYams ? [ .define("OPENAPI_USE_YAMS") ] : [],
-            linkerSettings: {
-                var flags: [LinkerSetting] = []
-                if let lib = env["SDL3_LIB_DIR"], !lib.isEmpty {
-                    flags.append(.unsafeFlags(["-L\(lib)"]))
-                }
-                // Fallback common lib roots
-                flags.append(.unsafeFlags(["-L/usr/local/lib"]))
-                return flags
-            }()
-        ),
-        .target(
-            name: "SDLKitTTF",
-            dependencies: ["SDLKit", "CSDL3TTF"],
-            path: "Sources/SDLKitTTF"
-        ),
-        .testTarget(
-            name: "SDLKitTests",
-            dependencies: ["SDLKit"],
-            path: "Tests/SDLKitTests"
-        ),
-        .executableTarget(
-            name: "SDLKitDemo",
-            dependencies: ["SDLKit"],
-            path: "Sources/SDLKitDemo"
+    targets: {
+        var targets: [Target] = []
+
+        if hasSDL3 {
+            targets.append(
+                .systemLibrary(
+                    name: "CSDL3",
+                    pkgConfig: "sdl3",
+                    providers: [
+                        .brew(["sdl3"]),
+                        .apt(["libsdl3-dev"])
+                    ]
+                )
+            )
+        } else {
+            targets.append(
+                .target(
+                    name: "CSDL3",
+                    path: "Sources/CSDL3Stub",
+                    publicHeadersPath: "include"
+                )
+            )
+        }
+
+        if hasSDL3Image {
+            targets.append(
+                .systemLibrary(
+                    name: "CSDL3IMAGE",
+                    pkgConfig: "sdl3-image",
+                    providers: [
+                        .brew(["sdl3_image"]),
+                        .apt(["libsdl3-image-dev"])
+                    ]
+                )
+            )
+        } else {
+            targets.append(
+                .target(
+                    name: "CSDL3IMAGE",
+                    path: "Sources/CSDL3ImageStub",
+                    publicHeadersPath: "include"
+                )
+            )
+        }
+
+        if hasSDL3TTF {
+            targets.append(
+                .systemLibrary(
+                    name: "CSDL3TTF",
+                    pkgConfig: "sdl3-ttf",
+                    providers: [
+                        .brew(["sdl3_ttf"]),
+                        .apt(["libsdl3-ttf-dev"])
+                    ]
+                )
+            )
+        } else {
+            targets.append(
+                .target(
+                    name: "CSDL3TTF",
+                    path: "Sources/CSDL3TTFStub",
+                    publicHeadersPath: "include"
+                )
+            )
+        }
+
+        targets.append(
+            .target(
+                name: "SDLKit",
+                dependencies: {
+                    var deps: [Target.Dependency] = [
+                        "CSDL3",
+                        .target(name: "CSDL3IMAGE", condition: .when(platforms: [.macOS, .linux]))
+                    ]
+                    if useYams { deps.append(.product(name: "Yams", package: "Yams")) }
+                    return deps
+                }(),
+                path: "Sources/SDLKit",
+                cSettings: {
+                    var flags: [CSetting] = []
+                    if let inc = env["SDL3_INCLUDE_DIR"], !inc.isEmpty {
+                        flags.append(.unsafeFlags(["-I\(inc)"]))
+                    }
+                    // Fallback common include roots
+                    flags.append(.unsafeFlags(["-I/usr/local/include"]))
+                    flags.append(.unsafeFlags(["-I/usr/include"]))
+                    return flags
+                }(),
+                swiftSettings: useYams ? [ .define("OPENAPI_USE_YAMS") ] : [],
+                linkerSettings: {
+                    var flags: [LinkerSetting] = []
+                    if let lib = env["SDL3_LIB_DIR"], !lib.isEmpty {
+                        flags.append(.unsafeFlags(["-L\(lib)"]))
+                    }
+                    // Fallback common lib roots
+                    flags.append(.unsafeFlags(["-L/usr/local/lib"]))
+                    return flags
+                }()
+            )
         )
-    ]
+
+        targets.append(
+            .target(
+                name: "SDLKitTTF",
+                dependencies: ["SDLKit", "CSDL3TTF"],
+                path: "Sources/SDLKitTTF"
+            )
+        )
+
+        targets.append(
+            .testTarget(
+                name: "SDLKitTests",
+                dependencies: ["SDLKit"],
+                path: "Tests/SDLKitTests"
+            )
+        )
+
+        targets.append(
+            .executableTarget(
+                name: "SDLKitDemo",
+                dependencies: ["SDLKit"],
+                path: "Sources/SDLKitDemo"
+            )
+        )
+
+        return targets
+    }()
 )

--- a/Sources/CSDL3ImageStub/include/shim_image.h
+++ b/Sources/CSDL3ImageStub/include/shim_image.h
@@ -1,0 +1,2 @@
+// Forward to the canonical SDL3_image shim declarations for stub builds.
+#include "../../CSDL3IMAGE/shim_image.h"

--- a/Sources/CSDL3Stub/include/shim.h
+++ b/Sources/CSDL3Stub/include/shim.h
@@ -1,0 +1,2 @@
+// Forwarding header that reuses the canonical SDL3 shim declarations.
+#include "../../CSDL3/shim.h"

--- a/Sources/CSDL3Stub/shim_stub.c
+++ b/Sources/CSDL3Stub/shim_stub.c
@@ -1,0 +1,322 @@
+#include <stdlib.h>
+#include <string.h>
+#include "../CSDL3/shim.h"
+
+// Minimal stub implementations that satisfy the shim symbol surface when SDL3
+// headers/libraries are unavailable. All functions return failure defaults.
+
+static const char *SDLKIT_STUB_ERROR_MESSAGE = "SDLKit SDL3 stub: SDL unavailable";
+
+const char *SDLKit_GetError(void) {
+    return SDLKIT_STUB_ERROR_MESSAGE;
+}
+
+int SDLKit_Init(uint32_t flags) {
+    (void)flags;
+    return -1;
+}
+
+SDL_Window *SDLKit_CreateWindow(const char *title, int32_t width, int32_t height, uint32_t flags) {
+    (void)title; (void)width; (void)height; (void)flags;
+    return NULL;
+}
+
+void SDLKit_DestroyWindow(SDL_Window *window) {
+    (void)window;
+}
+
+void SDLKit_ShowWindow(SDL_Window *window) {
+    (void)window;
+}
+
+void SDLKit_HideWindow(SDL_Window *window) {
+    (void)window;
+}
+
+void SDLKit_SetWindowTitle(SDL_Window *window, const char *title) {
+    (void)window; (void)title;
+}
+
+const char *SDLKit_GetWindowTitle(SDL_Window *window) {
+    (void)window;
+    return "SDLKit Stub Window";
+}
+
+void SDLKit_SetWindowPosition(SDL_Window *window, int x, int y) {
+    (void)window; (void)x; (void)y;
+}
+
+void SDLKit_GetWindowPosition(SDL_Window *window, int *x, int *y) {
+    (void)window;
+    if (x) { *x = 0; }
+    if (y) { *y = 0; }
+}
+
+void SDLKit_SetWindowSize(SDL_Window *window, int w, int h) {
+    (void)window; (void)w; (void)h;
+}
+
+void SDLKit_GetWindowSize(SDL_Window *window, int *w, int *h) {
+    (void)window;
+    if (w) { *w = 0; }
+    if (h) { *h = 0; }
+}
+
+void SDLKit_MaximizeWindow(SDL_Window *window) {
+    (void)window;
+}
+
+void SDLKit_MinimizeWindow(SDL_Window *window) {
+    (void)window;
+}
+
+void SDLKit_RestoreWindow(SDL_Window *window) {
+    (void)window;
+}
+
+int SDLKit_SetWindowFullscreen(SDL_Window *window, int enabled) {
+    (void)window; (void)enabled;
+    return -1;
+}
+
+int SDLKit_SetWindowOpacity(SDL_Window *window, float opacity) {
+    (void)window; (void)opacity;
+    return -1;
+}
+
+int SDLKit_SetWindowAlwaysOnTop(SDL_Window *window, int enabled) {
+    (void)window; (void)enabled;
+    return -1;
+}
+
+void SDLKit_CenterWindow(SDL_Window *window) {
+    (void)window;
+}
+
+int SDLKit_SetClipboardText(const char *text) {
+    (void)text;
+    return -1;
+}
+
+char *SDLKit_GetClipboardText(void) {
+    return NULL;
+}
+
+void SDLKit_free(void *p) {
+    free(p);
+}
+
+void SDLKit_GetMouseState(int *x, int *y, unsigned int *buttons) {
+    if (x) { *x = 0; }
+    if (y) { *y = 0; }
+    if (buttons) { *buttons = 0; }
+}
+
+int SDLKit_GetModMask(void) {
+    return 0;
+}
+
+int SDLKit_GetNumVideoDisplays(void) {
+    return 0;
+}
+
+const char *SDLKit_GetDisplayName(int index) {
+    (void)index;
+    return "SDLKit Stub Display";
+}
+
+int SDLKit_GetDisplayBounds(int index, int *x, int *y, int *w, int *h) {
+    (void)index;
+    if (x) { *x = 0; }
+    if (y) { *y = 0; }
+    if (w) { *w = 0; }
+    if (h) { *h = 0; }
+    return -1;
+}
+
+SDL_Renderer *SDLKit_CreateRenderer(SDL_Window *window, uint32_t flags) {
+    (void)window; (void)flags;
+    return NULL;
+}
+
+int SDLKit_SetRenderDrawColor(SDL_Renderer *renderer, uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
+    (void)renderer; (void)r; (void)g; (void)b; (void)a;
+    return -1;
+}
+
+int SDLKit_RenderClear(SDL_Renderer *renderer) {
+    (void)renderer;
+    return -1;
+}
+
+int SDLKit_RenderFillRect(SDL_Renderer *renderer, const struct SDL_FRect *rect) {
+    (void)renderer; (void)rect;
+    return -1;
+}
+
+int SDLKit_RenderFillRects(struct SDL_Renderer *renderer, const struct SDL_FRect *rects, int count) {
+    (void)renderer; (void)rects; (void)count;
+    return -1;
+}
+
+int SDLKit_RenderRects(struct SDL_Renderer *renderer, const struct SDL_FRect *rects, int count) {
+    (void)renderer; (void)rects; (void)count;
+    return -1;
+}
+
+int SDLKit_RenderPoints(struct SDL_Renderer *renderer, const struct SDL_FPoint *points, int count) {
+    (void)renderer; (void)points; (void)count;
+    return -1;
+}
+
+int SDLKit_RenderLine(struct SDL_Renderer *renderer, float x1, float y1, float x2, float y2) {
+    (void)renderer; (void)x1; (void)y1; (void)x2; (void)y2;
+    return -1;
+}
+
+void SDLKit_RenderPresent(SDL_Renderer *renderer) {
+    (void)renderer;
+}
+
+void SDLKit_GetRenderOutputSize(struct SDL_Renderer *renderer, int *w, int *h) {
+    (void)renderer;
+    if (w) { *w = 0; }
+    if (h) { *h = 0; }
+}
+
+void SDLKit_GetRenderScale(struct SDL_Renderer *renderer, float *sx, float *sy) {
+    (void)renderer;
+    if (sx) { *sx = 1.0f; }
+    if (sy) { *sy = 1.0f; }
+}
+
+int SDLKit_SetRenderScale(struct SDL_Renderer *renderer, float sx, float sy) {
+    (void)renderer; (void)sx; (void)sy;
+    return -1;
+}
+
+void SDLKit_GetRenderDrawColor(struct SDL_Renderer *renderer, uint8_t *r, uint8_t *g, uint8_t *b, uint8_t *a) {
+    (void)renderer;
+    if (r) { *r = 0; }
+    if (g) { *g = 0; }
+    if (b) { *b = 0; }
+    if (a) { *a = 0; }
+}
+
+int SDLKit_SetRenderViewport(struct SDL_Renderer *renderer, int x, int y, int w, int h) {
+    (void)renderer; (void)x; (void)y; (void)w; (void)h;
+    return -1;
+}
+
+void SDLKit_GetRenderViewport(struct SDL_Renderer *renderer, int *x, int *y, int *w, int *h) {
+    (void)renderer;
+    if (x) { *x = 0; }
+    if (y) { *y = 0; }
+    if (w) { *w = 0; }
+    if (h) { *h = 0; }
+}
+
+int SDLKit_SetRenderClipRect(struct SDL_Renderer *renderer, int x, int y, int w, int h) {
+    (void)renderer; (void)x; (void)y; (void)w; (void)h;
+    return -1;
+}
+
+int SDLKit_DisableRenderClipRect(struct SDL_Renderer *renderer) {
+    (void)renderer;
+    return -1;
+}
+
+void SDLKit_GetRenderClipRect(struct SDL_Renderer *renderer, int *x, int *y, int *w, int *h) {
+    (void)renderer;
+    if (x) { *x = 0; }
+    if (y) { *y = 0; }
+    if (w) { *w = 0; }
+    if (h) { *h = 0; }
+}
+
+int SDLKit_PollEvent(SDLKit_Event *out) {
+    if (out) {
+        memset(out, 0, sizeof(*out));
+    }
+    return 0;
+}
+
+int SDLKit_WaitEventTimeout(SDLKit_Event *out, int timeout_ms) {
+    (void)timeout_ms;
+    if (out) {
+        memset(out, 0, sizeof(*out));
+    }
+    return 0;
+}
+
+int SDLKit_TTF_Init(void) {
+    return -1;
+}
+
+SDLKit_TTF_Font *SDLKit_TTF_OpenFont(const char *path, int ptsize) {
+    (void)path; (void)ptsize;
+    return NULL;
+}
+
+void SDLKit_TTF_CloseFont(SDLKit_TTF_Font *font) {
+    (void)font;
+}
+
+struct SDL_Surface *SDLKit_TTF_RenderUTF8_Blended(SDLKit_TTF_Font *font, const char *text,
+                                                  uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
+    (void)font; (void)text; (void)r; (void)g; (void)b; (void)a;
+    return NULL;
+}
+
+struct SDL_Texture *SDLKit_CreateTextureFromSurface(struct SDL_Renderer *renderer, struct SDL_Surface *surface) {
+    (void)renderer; (void)surface;
+    return NULL;
+}
+
+void SDLKit_DestroySurface(struct SDL_Surface *surface) {
+    (void)surface;
+}
+
+void SDLKit_DestroyTexture(struct SDL_Texture *tex) {
+    (void)tex;
+}
+
+void SDLKit_GetTextureSize(struct SDL_Texture *tex, int *w, int *h) {
+    (void)tex;
+    if (w) { *w = 0; }
+    if (h) { *h = 0; }
+}
+
+int SDLKit_RenderTexture(struct SDL_Renderer *renderer, struct SDL_Texture *tex, const struct SDL_FRect *src, const struct SDL_FRect *dst) {
+    (void)renderer; (void)tex; (void)src; (void)dst;
+    return -1;
+}
+
+int SDLKit_RenderTextureRotated(struct SDL_Renderer *renderer, struct SDL_Texture *tex, const struct SDL_FRect *src, const struct SDL_FRect *dst, double angle, int hasCenter, float cx, float cy) {
+    (void)renderer; (void)tex; (void)src; (void)dst; (void)angle; (void)hasCenter; (void)cx; (void)cy;
+    return -1;
+}
+
+struct SDL_Surface *SDLKit_LoadBMP(const char *path) {
+    (void)path;
+    return NULL;
+}
+
+struct SDL_Surface *SDLKit_CreateSurfaceFrom(int width, int height, unsigned int format, void *pixels, int pitch) {
+    (void)width; (void)height; (void)format; (void)pixels; (void)pitch;
+    return NULL;
+}
+
+struct SDL_RWops *SDLKit_RWFromFile(const char *file, const char *mode) {
+    (void)file; (void)mode;
+    return NULL;
+}
+
+unsigned int SDLKit_PixelFormat_ABGR8888(void) {
+    return 0;
+}
+
+int SDLKit_RenderReadPixels(struct SDL_Renderer *renderer, int x, int y, int w, int h, void *pixels, int pitch) {
+    (void)renderer; (void)x; (void)y; (void)w; (void)h; (void)pixels; (void)pitch;
+    return -1;
+}

--- a/Sources/CSDL3TTFStub/include/shim_ttf.h
+++ b/Sources/CSDL3TTFStub/include/shim_ttf.h
@@ -1,0 +1,2 @@
+// Forward to the canonical SDL3_ttf shim declarations for stub builds.
+#include "../../CSDL3TTF/shim_ttf.h"

--- a/Tests/SDLKitTests/FontResolverTests.swift
+++ b/Tests/SDLKitTests/FontResolverTests.swift
@@ -1,0 +1,54 @@
+#if os(Linux)
+import Foundation
+import XCTest
+@testable import SDLKit
+
+final class FontResolverTests: XCTestCase {
+    func testSystemDefaultFontResolvesWhenCandidateExists() async throws {
+        let fileManager = FileManager.default
+        let candidateFiles = [
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+            "/usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf",
+            "/usr/share/fonts/truetype/freefont/FreeSans.ttf",
+            "/usr/share/fonts/truetype/ubuntu/Ubuntu-R.ttf"
+        ]
+        let candidateDirectories = [
+            "/usr/share/fonts/truetype",
+            "/usr/share/fonts/opentype",
+            "/usr/share/fonts",
+            "/usr/local/share/fonts"
+        ]
+
+        var knownReadableFont: String?
+        for path in candidateFiles where fileManager.isReadableFile(atPath: path) {
+            knownReadableFont = path
+            break
+        }
+
+        if knownReadableFont == nil {
+            directorySearch: for directory in candidateDirectories {
+                var isDirectory: ObjCBool = false
+                guard fileManager.fileExists(atPath: directory, isDirectory: &isDirectory), isDirectory.boolValue else { continue }
+                let url = URL(fileURLWithPath: directory, isDirectory: true)
+                guard let enumerator = fileManager.enumerator(at: url, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles, .skipsPackageDescendants]) else {
+                    continue
+                }
+                for case let fileURL as URL in enumerator {
+                    if fileURL.pathExtension.lowercased() == "ttf" && fileManager.isReadableFile(atPath: fileURL.path) {
+                        knownReadableFont = fileURL.path
+                        break directorySearch
+                    }
+                }
+            }
+        }
+
+        guard knownReadableFont != nil else {
+            throw XCTSkip("No readable system font candidates available for test")
+        }
+
+        let resolved = await MainActor.run { SDLFontResolver.resolve(fontSpec: "system:default") }
+        let fontPath = try XCTUnwrap(resolved)
+        XCTAssertTrue(fileManager.isReadableFile(atPath: fontPath))
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add pkg-config detection with environment overrides so the manifest chooses between system libraries and in-tree stubs
- provide CSDL3/CSDL3Image/CSDL3TTF stub targets backed by no-op implementations to satisfy headless builds

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68da3cb724ec8333b65a59f5c1cb1004