### PR TITLE
Add summary for screenshot capture endpoint

### DIFF
--- a/Sources/SDLKit/Agent/OpenAPISpec.swift
+++ b/Sources/SDLKit/Agent/OpenAPISpec.swift
@@ -124,6 +124,8 @@ paths:
 
   /agent/gui/screenshot/capture:
     post:
+      summary: Capture window screenshot
+      description: Captures the current window contents and returns either raw ABGR pixels or a Base64 PNG depending on the requested format.
       operationId: screenshotCapture
       requestBody:
         required: true
@@ -438,6 +440,8 @@ components:
             ],
             "/agent/gui/screenshot/capture": [
                 "post": [
+                    "summary": "Capture window screenshot",
+                    "description": "Captures the current window contents and returns either raw ABGR pixels or a Base64 PNG depending on the requested format.",
                     "operationId": "screenshotCapture",
                     "requestBody": jsonRequest(reqRef("ScreenshotCaptureRequest")),
                     "responses": [

--- a/sdlkit.gui.v1.yaml
+++ b/sdlkit.gui.v1.yaml
@@ -729,6 +729,8 @@ paths:
         '200': { $ref: '#/components/responses/Ok' }
   /agent/gui/screenshot/capture:
     post:
+      summary: Capture window screenshot
+      description: Captures the current window contents and returns either raw ABGR pixels or a Base64 PNG depending on the requested format.
       operationId: screenshotCapture
       requestBody:
         required: true


### PR DESCRIPTION
## Summary
- add summary and description for the `/agent/gui/screenshot/capture` endpoint in the OpenAPI source
- mirror the updated documentation inside the embedded Swift OpenAPI spec to keep outputs aligned

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68da420f74e48333b844411f6100620f