### PR TITLE
Ensure OpenAPI overrides take precedence and stabilize JSON output

### DIFF
--- a/Sources/SDLKit/Agent/JSONTools.swift
+++ b/Sources/SDLKit/Agent/JSONTools.swift
@@ -392,6 +392,12 @@ public struct SDLKitJSONAgent {
             if let entry = fetchFile(at: envPath, allowedExtensions: [".yaml", ".yml"], getCache: { externalYAMLCache }, setCache: setYAMLCache) {
                 return entry
             }
+            // When an explicit environment path is provided but either fails validation
+            // or the file is absent/unreadable, we intentionally skip probing fallback
+            // locations. The tests rely on falling back to the embedded spec instead of
+            // unexpectedly picking up repository-local files when the env override is
+            // unset or broken.
+            return nil
         }
         let candidates = [
             "sdlkit.gui.v1.yaml",
@@ -416,6 +422,9 @@ public struct SDLKitJSONAgent {
             if let entry = fetchFile(at: envPath, allowedExtensions: [".json"], getCache: { externalJSONCache }, setCache: setJSONCache) {
                 return entry
             }
+            // Honor the explicit environment path even when the target file is missing
+            // or has the wrong extension by avoiding any implicit fallback lookup.
+            return nil
         }
         let candidates = [
             "openapi.json",

--- a/Sources/SDLKit/Agent/OpenAPISpec.swift
+++ b/Sources/SDLKit/Agent/OpenAPISpec.swift
@@ -332,7 +332,7 @@ components:
 """
 
     // JSON representation of the same spec
-    public static var json: Data {
+    public static let json: Data = {
         let spec: [String: Any] = [
             "openapi": "3.1.0",
             "info": [
@@ -344,8 +344,8 @@ components:
             "paths": pathsJSON(),
             "components": componentsJSON()
         ]
-        return (try? JSONSerialization.data(withJSONObject: spec, options: [.prettyPrinted])) ?? Data("{}".utf8)
-    }
+        return (try? JSONSerialization.data(withJSONObject: spec, options: [.prettyPrinted, .sortedKeys])) ?? Data("{}".utf8)
+    }()
 
     private static func okResponseRef() -> [String: Any] { ["$ref": "#/components/responses/Ok"] }
     private static func errResponseRef() -> [String: Any] { ["$ref": "#/components/responses/Error"] }


### PR DESCRIPTION
## Summary
- stop the JSON agent from falling back to repository OpenAPI files when an explicit SDLKIT_OPENAPI_PATH is configured
- stabilize the embedded OpenAPI JSON payload by caching the serialization with sorted keys

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68da42f94600833399e570f87ba90b54