### PR TITLE
Add module map for SDL_ttf stub target

### DIFF
--- a/Sources/CSDL3TTFStub/module.modulemap
+++ b/Sources/CSDL3TTFStub/module.modulemap
@@ -1,0 +1,4 @@
+module CSDL3TTF {
+  header "shim_ttf.h"
+  export *
+}


### PR DESCRIPTION
## Summary
- add a module map to the CSDL3TTF stub target so it always vends a Clang module

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_b_68da46e1b7dc833395098f7ef100e73e