### PR TITLE
Fix SDLKitDemo dependency on SDLKitTTF

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -169,7 +169,10 @@ let package = Package(
         targets.append(
             .executableTarget(
                 name: "SDLKitDemo",
-                dependencies: ["SDLKit"],
+                dependencies: [
+                    "SDLKit",
+                    .target(name: "SDLKitTTF", condition: .when(platforms: [.macOS, .linux]))
+                ],
                 path: "Sources/SDLKitDemo"
             )
         )


### PR DESCRIPTION
## Summary
- add SDLKitTTF as a conditional dependency of the SDLKitDemo executable to ensure the module and its C shim build

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_b_68da85bef6788333a9f8ef18aa8cd4d6