### PR TITLE
Handle OpenAPI override caching for JSON files

### DIFF
--- a/Sources/SDLKit/Agent/OpenAPISpec.swift
+++ b/Sources/SDLKit/Agent/OpenAPISpec.swift
@@ -344,7 +344,7 @@ components:
             "paths": pathsJSON(),
             "components": componentsJSON()
         ]
-        return (try? JSONSerialization.data(withJSONObject: spec, options: [.prettyPrinted])) ?? Data("{}".utf8)
+        return (try? JSONSerialization.data(withJSONObject: spec, options: [.prettyPrinted, .sortedKeys])) ?? Data("{}".utf8)
     }
 
     private static func okResponseRef() -> [String: Any] { ["$ref": "#/components/responses/Ok"] }


### PR DESCRIPTION
## Summary
- avoid converting the embedded YAML spec when the SDLKIT_OPENAPI_PATH env var points to a JSON file
- read SDLKIT_OPENAPI_PATH with getenv so tests can override it at runtime
- serialize the embedded OpenAPI JSON with sorted keys for deterministic bytes

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68da8f6f1b908333bcae2d48d016976e