### PR TITLE
Enforce SDLKit window limit configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,12 @@ This package is designed to work with the Fountain‑Coach SDL3 fork:
   - Then in Swift: `import SDLKitTTF` (this also re‑exports `SDLKit`).
   - Without `SDLKitTTF`, `drawText` remains available but returns `notImplemented` if SDL_ttf isn’t present at build/link time.
 
+## Configuration
+
+The agent reads several environment variables at runtime. Key options include:
+
+- `SDLKIT_MAX_WINDOWS` — soft cap on concurrently open windows. Defaults to `8`. Set to any positive integer to raise or lower the cap. Non-positive or non-numeric values fall back to the default.
+
 ### Colors
 
 - Colors accept integer ARGB (0xAARRGGBB) or strings.

--- a/Sources/SDLKit/Agent/SDLKitGUIAgent.swift
+++ b/Sources/SDLKit/Agent/SDLKitGUIAgent.swift
@@ -15,6 +15,11 @@ open class SDLKitGUIAgent {
     public func openWindow(title: String, width: Int, height: Int) throws -> Int {
         guard width > 0, height > 0 else { throw AgentError.invalidArgument("width/height must be > 0") }
         guard SDLKitConfig.guiEnabled else { throw AgentError.sdlUnavailable }
+        let limit = SDLKitConfig.maxWindows
+        guard windows.count < limit else {
+            SDLLogger.warn("SDLKit.Agent", "Refusing to open window: limit=\(limit) current=\(windows.count)")
+            throw AgentError.invalidArgument("Window limit of \(limit) reached")
+        }
 
         let window = SDLWindow(config: .init(title: title, width: width, height: height))
         try window.open()
@@ -24,6 +29,18 @@ open class SDLKitGUIAgent {
         windows[id] = WindowBundle(window: window, renderer: renderer)
         SDLLogger.info("SDLKit.Agent", "Opened window id=\(id) \(width)x\(height) title=\(title)")
         return id
+    }
+
+    internal func _testingPopulateWindows(count: Int) {
+        windows.removeAll()
+        nextID = 1
+        guard count > 0 else { return }
+        for _ in 0..<count {
+            let id = nextID; nextID += 1
+            let window = SDLWindow(config: .init(title: "test-\(id)", width: 1, height: 1))
+            let renderer = SDLRenderer(testingWidth: 1, testingHeight: 1)
+            windows[id] = WindowBundle(window: window, renderer: renderer)
+        }
     }
 
     public func closeWindow(windowId: Int) {

--- a/Sources/SDLKit/Core/SDLRenderer.swift
+++ b/Sources/SDLKit/Core/SDLRenderer.swift
@@ -25,6 +25,15 @@ public final class SDLRenderer {
         #endif
     }
 
+    internal init(testingWidth: Int, testingHeight: Int) {
+        self.width = testingWidth
+        self.height = testingHeight
+        #if canImport(CSDL3) && !HEADLESS_CI
+        handle = nil
+        textures = [:]
+        #endif
+    }
+
     public func present() {
         #if canImport(CSDL3) && !HEADLESS_CI
         if let r = handle { SDLKit_RenderPresent(r) }

--- a/Sources/SDLKit/SDLKit.swift
+++ b/Sources/SDLKit/SDLKit.swift
@@ -12,6 +12,18 @@ public enum SDLKitConfig {
         return env == "auto" ? .auto : .explicit
     }
 
+    public static var maxWindows: Int {
+        let defaultValue = 8
+        guard let raw = ProcessInfo.processInfo.environment["SDLKIT_MAX_WINDOWS"] else {
+            return defaultValue
+        }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let parsed = Int(trimmed), parsed > 0 else {
+            return defaultValue
+        }
+        return parsed
+    }
+
     public enum PresentPolicy { case auto, explicit }
 }
 

--- a/Tests/SDLKitTests/SDLKitGUIAgentLimitTests.swift
+++ b/Tests/SDLKitTests/SDLKitGUIAgentLimitTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import SDLKit
+
+final class SDLKitGUIAgentLimitTests: XCTestCase {
+    func testOpenWindowHonorsMaxWindowCap() async throws {
+        let key = "SDLKIT_MAX_WINDOWS"
+        let priorValue = getenv(key).map { String(cString: $0) }
+        setenv(key, "2", 1)
+        defer {
+            if let priorValue {
+                setenv(key, priorValue, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+
+        try await MainActor.run {
+            let agent = SDLKitGUIAgent()
+            agent._testingPopulateWindows(count: SDLKitConfig.maxWindows)
+            XCTAssertThrowsError(try agent.openWindow(title: "overflow", width: 100, height: 100)) { error in
+                guard case AgentError.invalidArgument(let message) = error else {
+                    return XCTFail("Expected invalidArgument, got: \(error)")
+                }
+                XCTAssertTrue(message.contains("2"), "Error message should mention the configured limit")
+            }
+        }
+    }
+}

--- a/Tests/SDLKitTests/SDLKitTests.swift
+++ b/Tests/SDLKitTests/SDLKitTests.swift
@@ -15,6 +15,20 @@ final class SDLKitTests: XCTestCase {
             // If not set, we only assert that guiEnabled returns a Bool (no crash)
             _ = SDLKitConfig.guiEnabled
         }
+
+        let key = "SDLKIT_MAX_WINDOWS"
+        let prior = getenv(key).map { String(cString: $0) }
+        setenv(key, "12", 1)
+        XCTAssertEqual(SDLKitConfig.maxWindows, 12)
+        setenv(key, "0", 1)
+        XCTAssertEqual(SDLKitConfig.maxWindows, 8)
+        setenv(key, "not-a-number", 1)
+        XCTAssertEqual(SDLKitConfig.maxWindows, 8)
+        if let prior {
+            setenv(key, prior, 1)
+        } else {
+            unsetenv(key)
+        }
     }
 
     func testColorParsing() throws {


### PR DESCRIPTION
## Summary
- add a configurable SDLKitConfig.maxWindows that reads SDLKIT_MAX_WINDOWS and clamps invalid values
- guard SDLKitGUIAgent.openWindow against the configured cap and expose a testing helper
- document the new configuration option and add unit tests covering the limit

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68daa178e4488333866cb3f44e8e1336