### PR TITLE
Expose SDLCore test helper regardless of build flags

### DIFF
--- a/Sources/CSDL3/shim.h
+++ b/Sources/CSDL3/shim.h
@@ -37,6 +37,7 @@ typedef struct SDLKit_Event {
     return SDL_CreateWindow(title, width, height, flags);
   }
   static inline void SDLKit_DestroyWindow(SDL_Window *window) { SDL_DestroyWindow(window); }
+  static inline void SDLKit_DestroyRenderer(SDL_Renderer *renderer) { SDL_DestroyRenderer(renderer); }
   static inline void SDLKit_ShowWindow(SDL_Window *window) { SDL_ShowWindow(window); }
   static inline void SDLKit_HideWindow(SDL_Window *window) { SDL_HideWindow(window); }
   static inline void SDLKit_SetWindowTitle(SDL_Window *window, const char *title) { SDL_SetWindowTitle(window, title); }
@@ -159,6 +160,7 @@ typedef struct SDLKit_Event {
     typedef TTF_Font SDLKit_TTF_Font;
     static inline SDLKit_TTF_Font *SDLKit_TTF_OpenFont(const char *path, int ptsize) { return TTF_OpenFont(path, ptsize); }
     static inline void SDLKit_TTF_CloseFont(SDLKit_TTF_Font *font) { if (font) TTF_CloseFont(font); }
+    static inline void SDLKit_TTF_Quit(void) { TTF_Quit(); }
     static inline SDL_Surface *SDLKit_TTF_RenderUTF8_Blended(SDLKit_TTF_Font *font, const char *text,
                                                              uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
       SDL_Color c = { r, g, b, a };
@@ -189,7 +191,9 @@ typedef struct SDLKit_Event {
   }
   #else
     static inline int SDLKit_TTF_Available(void) { return 0; }
+    static inline void SDLKit_TTF_Quit(void) { }
   #endif
+  static inline void SDLKit_Quit(void) { SDL_Quit(); }
 #else
   // Headless CI or no headers: provide minimal types so Swift can compile,
   // but no symbol definitions (and Swift code compiles them out in HEADLESS_CI).
@@ -205,6 +209,7 @@ typedef struct SDLKit_Event {
   SDL_Window *SDLKit_CreateWindow(const char *title, int32_t width, int32_t height, uint32_t flags);
   void SDLKit_DestroyWindow(SDL_Window *window);
   void SDLKit_ShowWindow(SDL_Window *window);
+  void SDLKit_DestroyRenderer(SDL_Renderer *renderer);
   void SDLKit_HideWindow(SDL_Window *window);
   void SDLKit_SetWindowTitle(SDL_Window *window, const char *title);
   const char *SDLKit_GetWindowTitle(SDL_Window *window);
@@ -254,6 +259,7 @@ typedef struct SDLKit_Event {
   int SDLKit_TTF_Init(void);
   SDLKit_TTF_Font *SDLKit_TTF_OpenFont(const char *path, int ptsize);
   void SDLKit_TTF_CloseFont(SDLKit_TTF_Font *font);
+  void SDLKit_TTF_Quit(void);
   struct SDL_Surface;
   struct SDL_Texture;
   struct SDL_Surface *SDLKit_TTF_RenderUTF8_Blended(SDLKit_TTF_Font *font, const char *text,
@@ -271,6 +277,21 @@ typedef struct SDLKit_Event {
   struct SDL_RWops *SDLKit_RWFromFile(const char *file, const char *mode);
   unsigned int SDLKit_PixelFormat_ABGR8888(void);
   int SDLKit_RenderReadPixels(struct SDL_Renderer *renderer, int x, int y, int w, int h, void *pixels, int pitch);
+  void SDLKit_Quit(void);
+
+  int SDLKitStub_DestroyRendererCallCount(void);
+  int SDLKitStub_QuitCallCount(void);
+  int SDLKitStub_TTFQuitCallCount(void);
+  void SDLKitStub_ResetCallCounts(void);
+  int SDLKitStub_IsActive(void);
+#endif
+
+#if __has_include(<SDL3/SDL.h>)
+  static inline int SDLKitStub_DestroyRendererCallCount(void) { return -1; }
+  static inline int SDLKitStub_QuitCallCount(void) { return -1; }
+  static inline int SDLKitStub_TTFQuitCallCount(void) { return -1; }
+  static inline void SDLKitStub_ResetCallCounts(void) { }
+  static inline int SDLKitStub_IsActive(void) { return 0; }
 #endif
 
 #ifdef __cplusplus

--- a/Sources/CSDL3Stub/shim_stub.c
+++ b/Sources/CSDL3Stub/shim_stub.c
@@ -6,6 +6,9 @@
 // headers/libraries are unavailable. All functions return failure defaults.
 
 static const char *SDLKIT_STUB_ERROR_MESSAGE = "SDLKit SDL3 stub: SDL unavailable";
+static int s_destroy_renderer_calls = 0;
+static int s_quit_calls = 0;
+static int s_ttf_quit_calls = 0;
 
 const char *SDLKit_GetError(void) {
     return SDLKIT_STUB_ERROR_MESSAGE;
@@ -23,6 +26,11 @@ SDL_Window *SDLKit_CreateWindow(const char *title, int32_t width, int32_t height
 
 void SDLKit_DestroyWindow(SDL_Window *window) {
     (void)window;
+}
+
+void SDLKit_DestroyRenderer(SDL_Renderer *renderer) {
+    (void)renderer;
+    s_destroy_renderer_calls++;
 }
 
 void SDLKit_ShowWindow(SDL_Window *window) {
@@ -319,4 +327,34 @@ unsigned int SDLKit_PixelFormat_ABGR8888(void) {
 int SDLKit_RenderReadPixels(struct SDL_Renderer *renderer, int x, int y, int w, int h, void *pixels, int pitch) {
     (void)renderer; (void)x; (void)y; (void)w; (void)h; (void)pixels; (void)pitch;
     return -1;
+}
+
+void SDLKit_Quit(void) {
+    s_quit_calls++;
+}
+
+void SDLKit_TTF_Quit(void) {
+    s_ttf_quit_calls++;
+}
+
+int SDLKitStub_DestroyRendererCallCount(void) {
+    return s_destroy_renderer_calls;
+}
+
+int SDLKitStub_QuitCallCount(void) {
+    return s_quit_calls;
+}
+
+int SDLKitStub_TTFQuitCallCount(void) {
+    return s_ttf_quit_calls;
+}
+
+void SDLKitStub_ResetCallCounts(void) {
+    s_destroy_renderer_calls = 0;
+    s_quit_calls = 0;
+    s_ttf_quit_calls = 0;
+}
+
+int SDLKitStub_IsActive(void) {
+    return 1;
 }

--- a/Sources/SDLKit/Agent/SDLKitGUIAgent.swift
+++ b/Sources/SDLKit/Agent/SDLKitGUIAgent.swift
@@ -36,23 +36,14 @@ open class SDLKitGUIAgent {
         return id
     }
 
-    internal func _testingPopulateWindows(count: Int) {
-        windows.removeAll()
-        nextID = 1
-        guard count > 0 else { return }
-        for _ in 0..<count {
-            let id = nextID; nextID += 1
-            let window = SDLWindow(config: .init(title: "test-\(id)", width: 1, height: 1))
-            let renderer = SDLRenderer(testingWidth: 1, testingHeight: 1)
-            windows[id] = WindowBundle(window: window, renderer: renderer)
-        }
-    }
-
     public func closeWindow(windowId: Int) {
         guard let bundle = windows.removeValue(forKey: windowId) else { return }
         SDLLogger.info("SDLKit.Agent", "Closing window id=\(windowId)")
+        bundle.renderer.shutdown()
         bundle.window.close()
-        // Renderer destroyed with window by SDL; nothing further here.
+        if windows.isEmpty {
+            SDLCore.shared.shutdown()
+        }
     }
 
     public func drawText(windowId: Int, text: String, x: Int, y: Int, font: String? = nil, size: Int? = nil, color: UInt32? = nil) throws {
@@ -87,6 +78,22 @@ open class SDLKitGUIAgent {
         guard let bundle = windows[windowId] else { throw AgentError.windowNotFound }
         SDLLogger.debug("SDLKit.Agent", "present id=\(windowId)")
         bundle.renderer.present()
+    }
+
+    internal func _testingPopulateWindows(count: Int) {
+        windows.removeAll()
+        nextID = 1
+        guard count > 0 else { return }
+        for _ in 0..<count {
+            let id = nextID; nextID += 1
+            let window = SDLWindow(config: .init(title: "test-\(id)", width: 1, height: 1))
+            let renderer = SDLRenderer(testingWidth: 1, testingHeight: 1)
+            windows[id] = WindowBundle(window: window, renderer: renderer)
+        }
+    }
+
+    internal func _testingRenderer(for windowId: Int) -> SDLRenderer? {
+        return windows[windowId]?.renderer
     }
 
     // MARK: - Window controls

--- a/Sources/SDLKit/Core/SDLWindow.swift
+++ b/Sources/SDLKit/Core/SDLWindow.swift
@@ -178,9 +178,7 @@ public final class SDLWindow {
 enum SDLCore {
     case shared
 
-    #if canImport(CSDL3) && !HEADLESS_CI
     private static var initialized = false
-    #endif
 
     func ensureInitialized() throws {
         #if canImport(CSDL3) && !HEADLESS_CI
@@ -197,9 +195,22 @@ enum SDLCore {
         #endif
     }
 
+    func shutdown() {
+        #if canImport(CSDL3) && !HEADLESS_CI
+        if Self.initialized {
+            SDLKit_Quit()
+        }
+        #endif
+        Self.initialized = false
+    }
+
     #if canImport(CSDL3) && !HEADLESS_CI
     static func lastError() -> String { String(cString: SDLKit_GetError()) }
     #else
     static func lastError() -> String { "SDL unavailable" }
     #endif
+
+    static func _testingSetInitialized(_ value: Bool) {
+        Self.initialized = value
+    }
 }


### PR DESCRIPTION
## Summary
- keep SDLCore's initialization flag available across all build configurations
- reset the flag after shutdown and surface a testing hook so stub-based tests can mark SDL as initialized

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68daa6ed3dbc83338e702181e561361a