### PR TITLE
Expose native SDL window handles and Vulkan surface creation

### DIFF
--- a/Sources/CSDL3Stub/shim_stub.c
+++ b/Sources/CSDL3Stub/shim_stub.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 #include "../CSDL3/shim.h"
 
 // Minimal stub implementations that satisfy the shim symbol surface when SDL3
@@ -327,6 +328,24 @@ unsigned int SDLKit_PixelFormat_ABGR8888(void) {
 int SDLKit_RenderReadPixels(struct SDL_Renderer *renderer, int x, int y, int w, int h, void *pixels, int pitch) {
     (void)renderer; (void)x; (void)y; (void)w; (void)h; (void)pixels; (void)pitch;
     return -1;
+}
+
+void *SDLKit_MetalLayerForWindow(SDL_Window *window) {
+    (void)window;
+    return NULL;
+}
+
+void *SDLKit_Win32HWND(SDL_Window *window) {
+    (void)window;
+    return NULL;
+}
+
+bool SDLKit_CreateVulkanSurface(SDL_Window *window, VkInstance instance, VkSurfaceKHR *surface) {
+    (void)window; (void)instance;
+    if (surface) {
+        *surface = (VkSurfaceKHR)0;
+    }
+    return false;
 }
 
 void SDLKit_Quit(void) {

--- a/Sources/SDLKit/Agent/SDLKitGUIAgent.swift
+++ b/Sources/SDLKit/Agent/SDLKitGUIAgent.swift
@@ -157,6 +157,11 @@ open class SDLKitGUIAgent {
         return try bundle.window.info()
     }
 
+    public func nativeHandles(windowId: Int) throws -> SDLWindow.NativeHandles {
+        guard let bundle = windows[windowId] else { throw AgentError.windowNotFound }
+        return try bundle.window.nativeHandles()
+    }
+
     public func centerWindow(windowId: Int) throws {
         guard let bundle = windows[windowId] else { throw AgentError.windowNotFound }
         try bundle.window.center()


### PR DESCRIPTION
## Summary
- add shim helpers to fetch CAMetalLayer, Win32 HWND, and create Vulkan surfaces with real and stub implementations
- expose SDLWindow.NativeHandles and GUI agent forwarding to retrieve native handles and create Vulkan surfaces from Swift

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68dc07c431dc83338c8bc143eac63c93