### PR TITLE
Add platform-aware SDLKit demo handles smoke test

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -152,6 +152,14 @@ let package = Package(
 
         targets.append(
             .target(
+                name: "VulkanMinimal",
+                path: "Sources/VulkanMinimal",
+                publicHeadersPath: "include"
+            )
+        )
+
+        targets.append(
+            .target(
                 name: "SDLKitTTF",
                 dependencies: ["SDLKit", "CSDL3TTF"],
                 path: "Sources/SDLKitTTF"
@@ -171,7 +179,8 @@ let package = Package(
                 name: "SDLKitDemo",
                 dependencies: [
                     "SDLKit",
-                    .target(name: "SDLKitTTF", condition: .when(platforms: [.macOS, .linux]))
+                    .target(name: "SDLKitTTF", condition: .when(platforms: [.macOS, .linux])),
+                    .target(name: "VulkanMinimal", condition: .when(platforms: [.linux]))
                 ],
                 path: "Sources/SDLKitDemo"
             )

--- a/Sources/SDLKitDemo/main.swift
+++ b/Sources/SDLKitDemo/main.swift
@@ -3,64 +3,156 @@ import SDLKit
 #if canImport(SDLKitTTF)
 import SDLKitTTF
 #endif
+#if canImport(QuartzCore)
+import QuartzCore
+#endif
+#if canImport(VulkanMinimal)
+import VulkanMinimal
+#endif
 
-#if os(macOS)
+#if HEADLESS_CI
+@main
+@MainActor
+struct DemoApp {
+    static func main() {
+        print("SDLKitDemo: skipped (HEADLESS_CI set)")
+    }
+}
+#elseif os(macOS) || os(Windows) || os(Linux)
 @main
 struct DemoApp {
+    private enum DemoPlatform: String {
+        case macOS
+        case windows
+        case linux
+    }
+
+    private struct ExitSignal: Error {}
+
     static func main() {
         guard SDLKitConfig.guiEnabled else {
             print("GUI disabled. Set SDLKIT_GUI_ENABLED=1 to enable.")
             return
         }
+
+        #if os(macOS)
+        let platform: DemoPlatform = .macOS
+        #elseif os(Windows)
+        let platform: DemoPlatform = .windows
+        #elseif os(Linux)
+        let platform: DemoPlatform = .linux
+        #else
+        let platform: DemoPlatform = .macOS
+        #endif
+
         let agent = SDLKitGUIAgent()
         do {
-            let win = try agent.openWindow(title: "SDLKit Demo", width: 640, height: 480)
-            // Clear background
-            try agent.clear(windowId: win, color: "#0F0F13")
-            // Draw a rectangle
-            try agent.drawRectangle(windowId: win, x: 40, y: 40, width: 200, height: 120, color: "#3366FF")
-            // Draw a line
-            try agent.drawLine(windowId: win, x1: 0, y1: 0, x2: 639, y2: 479, color: "#FFCC00")
-            // Draw a filled circle
-            try agent.drawCircleFilled(windowId: win, cx: 320, cy: 240, radius: 60, color: "#55FFAA")
-            // Try text if TTF is available
-            #if !HEADLESS_CI
-            do {
-                try agent.drawText(windowId: win, text: "SDLKit ✓", x: 20, y: 200, font: "/System/Library/Fonts/Supplemental/Arial Unicode.ttf", size: 22, color: 0xFFFFFFFF)
-            } catch AgentError.notImplemented {
-                print("SDL_ttf not available; skipping text rendering")
-            } catch {
-                print("Text draw error: \(error)")
-            }
-            #endif
-            try agent.present(windowId: win)
-
-            print("Demo running. Press any key or close window to exit...")
-            let deadline = Date().addingTimeInterval(10)
-            while Date() < deadline {
-                if let ev = try agent.captureEvent(windowId: win, timeoutMs: 100) {
-                    switch ev.type {
-                    case .quit, .windowClosed, .keyDown, .mouseDown:
-                        throw ExitSignal()
-                    default:
-                        break
-                    }
-                }
-            }
+            try runDemo(on: platform, agent: agent)
+            print("SDLKitDemo: completed smoke test for \(platform.rawValue)")
         } catch is ExitSignal {
-            // user requested exit
+            print("SDLKitDemo: user exit")
         } catch AgentError.sdlUnavailable {
             print("SDL unavailable on this build. Install SDL3 to run the demo.")
         } catch {
-            print("Demo error: \(error)")
+            print("SDLKitDemo error: \(error)")
         }
-        print("Demo exit.")
     }
-    struct ExitSignal: Error {}
+
+    @MainActor
+    private static func runDemo(on platform: DemoPlatform, agent: SDLKitGUIAgent) throws {
+        let windowId = try agent.openWindow(title: "SDLKit Demo", width: 640, height: 480)
+        defer { agent.closeWindow(windowId: windowId) }
+
+        try showcaseDrawing(windowId: windowId, agent: agent)
+        try logNativeHandles(for: platform, windowId: windowId, agent: agent)
+
+        let start = Date()
+        while Date().timeIntervalSince(start) < 2.0 {
+            if let event = try agent.captureEvent(windowId: windowId, timeoutMs: 100) {
+                switch event.type {
+                case .quit, .windowClosed, .keyDown, .mouseDown:
+                    throw ExitSignal()
+                default:
+                    break
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private static func showcaseDrawing(windowId: Int, agent: SDLKitGUIAgent) throws {
+        try agent.clear(windowId: windowId, color: "#0F0F13")
+        try agent.drawRectangle(windowId: windowId, x: 40, y: 40, width: 200, height: 120, color: "#3366FF")
+        try agent.drawLine(windowId: windowId, x1: 0, y1: 0, x2: 639, y2: 479, color: "#FFCC00")
+        try agent.drawCircleFilled(windowId: windowId, cx: 320, cy: 240, radius: 60, color: "#55FFAA")
+        #if canImport(SDLKitTTF)
+        do {
+            try agent.drawText(windowId: windowId, text: "SDLKit ✓", x: 20, y: 200, font: "/System/Library/Fonts/Supplemental/Arial Unicode.ttf", size: 22, color: 0xFFFFFFFF)
+        } catch AgentError.notImplemented {
+            print("SDL_ttf not available; skipping text rendering")
+        } catch {
+            print("Text draw error: \(error)")
+        }
+        #endif
+        try agent.present(windowId: windowId)
+    }
+
+    @MainActor
+    private static func logNativeHandles(for platform: DemoPlatform, windowId: Int, agent: SDLKitGUIAgent) throws {
+        let handles = try agent.nativeHandles(windowId: windowId)
+        switch platform {
+        case .macOS:
+            #if canImport(QuartzCore)
+            if let layer = handles.metalLayer as? CAMetalLayer {
+                let nameDescription: String
+                if let name = layer.name {
+                    if let stringName = name as? String {
+                        nameDescription = stringName
+                    } else {
+                        nameDescription = String(describing: name)
+                    }
+                } else {
+                    nameDescription = "nil"
+                }
+                print("SDLKitDemo: CAMetalLayer => class=\(String(describing: type(of: layer))) name=\(nameDescription)")
+            } else {
+                print("SDLKitDemo: CAMetalLayer unavailable on macOS")
+            }
+            #else
+            print("SDLKitDemo: QuartzCore unavailable on this build")
+            #endif
+        case .windows:
+            if let hwnd = handles.win32HWND {
+                let value = UInt(bitPattern: hwnd)
+                let formatted = String(format: "0x%016llX", UInt64(value))
+                print("SDLKitDemo: Win32 HWND => \(formatted)")
+            } else {
+                print("SDLKitDemo: Win32 HWND unavailable")
+            }
+        case .linux:
+            #if canImport(VulkanMinimal)
+            var instance = VulkanMinimalInstance()
+            let result = VulkanMinimalCreateInstance(&instance)
+            guard result == VK_SUCCESS, let vkInstance = instance.handle else {
+                print("SDLKitDemo: Vulkan instance creation failed (code=\(result))")
+                VulkanMinimalDestroyInstance(&instance)
+                return
+            }
+            defer { VulkanMinimalDestroyInstance(&instance) }
+            let surface = try handles.createVulkanSurface(instance: vkInstance)
+            let formattedSurface = String(format: "0x%016llX", UInt64(surface))
+            print("SDLKitDemo: Vulkan surface => \(formattedSurface)")
+            #else
+            print("SDLKitDemo: Vulkan headers unavailable; skipping surface creation")
+            #endif
+        }
+    }
 }
 #else
 @main
 struct DemoApp {
-    static func main() { print("SDLKitDemo: unsupported platform for this demo") }
+    static func main() {
+        print("SDLKitDemo: unsupported platform for this demo")
+    }
 }
 #endif

--- a/Sources/VulkanMinimal/VulkanMinimal.c
+++ b/Sources/VulkanMinimal/VulkanMinimal.c
@@ -1,0 +1,80 @@
+#include "VulkanMinimal.h"
+#include <string.h>
+#include <dlfcn.h>
+
+typedef VkResult (*PFN_vkCreateInstance)(const VkInstanceCreateInfo *, const VkAllocationCallbacks *, VkInstance *);
+typedef void (*PFN_vkDestroyInstance)(VkInstance, const VkAllocationCallbacks *);
+
+static void *vulkanLibraryHandle = NULL;
+static PFN_vkCreateInstance pfn_vkCreateInstance = NULL;
+static PFN_vkDestroyInstance pfn_vkDestroyInstance = NULL;
+
+static bool VulkanMinimalEnsureLoaded(void) {
+    if (pfn_vkCreateInstance && pfn_vkDestroyInstance) {
+        return true;
+    }
+
+    if (!vulkanLibraryHandle) {
+        const char *candidates[] = { "libvulkan.so.1", "libvulkan.so", NULL };
+        for (int i = 0; candidates[i] != NULL; ++i) {
+            vulkanLibraryHandle = dlopen(candidates[i], RTLD_NOW | RTLD_LOCAL);
+            if (vulkanLibraryHandle) {
+                break;
+            }
+        }
+    }
+
+    if (!vulkanLibraryHandle) {
+        return false;
+    }
+
+    pfn_vkCreateInstance = (PFN_vkCreateInstance)dlsym(vulkanLibraryHandle, "vkCreateInstance");
+    pfn_vkDestroyInstance = (PFN_vkDestroyInstance)dlsym(vulkanLibraryHandle, "vkDestroyInstance");
+
+    return (pfn_vkCreateInstance && pfn_vkDestroyInstance);
+}
+
+VkResult VulkanMinimalCreateInstance(VulkanMinimalInstance *instance) {
+    if (!instance) {
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    memset(instance, 0, sizeof(*instance));
+
+    if (!VulkanMinimalEnsureLoaded()) {
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    const char appName[] = "SDLKitDemo";
+    const char engineName[] = "SDLKit";
+
+    VkApplicationInfo appInfo;
+    memset(&appInfo, 0, sizeof(appInfo));
+    appInfo.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    appInfo.pApplicationName = appName;
+    appInfo.applicationVersion = VulkanMinimalMakeVersion(1, 0, 0);
+    appInfo.pEngineName = engineName;
+    appInfo.engineVersion = VulkanMinimalMakeVersion(0, 1, 0);
+    appInfo.apiVersion = VK_API_VERSION_1_0;
+
+    VkInstanceCreateInfo createInfo;
+    memset(&createInfo, 0, sizeof(createInfo));
+    createInfo.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    createInfo.pApplicationInfo = &appInfo;
+
+    VkResult result = pfn_vkCreateInstance(&createInfo, NULL, &instance->handle);
+    if (result != VK_SUCCESS) {
+        instance->handle = NULL;
+    }
+    return result;
+}
+
+void VulkanMinimalDestroyInstance(VulkanMinimalInstance *instance) {
+    if (!instance || !instance->handle) {
+        return;
+    }
+    if (VulkanMinimalEnsureLoaded()) {
+        pfn_vkDestroyInstance(instance->handle, NULL);
+    }
+    instance->handle = NULL;
+}

--- a/Sources/VulkanMinimal/include/VulkanMinimal.h
+++ b/Sources/VulkanMinimal/include/VulkanMinimal.h
@@ -1,0 +1,64 @@
+#ifndef SDLKIT_VULKAN_MINIMAL_H
+#define SDLKIT_VULKAN_MINIMAL_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct VkInstance_T *VkInstance;
+typedef uint32_t VkFlags;
+typedef VkFlags VkInstanceCreateFlags;
+typedef int32_t VkResult;
+typedef uint64_t VkSurfaceKHR;
+
+typedef struct VulkanMinimalInstance {
+    VkInstance handle;
+} VulkanMinimalInstance;
+
+typedef struct VkAllocationCallbacks VkAllocationCallbacks;
+
+typedef enum VkStructureType {
+    VK_STRUCTURE_TYPE_APPLICATION_INFO = 0,
+    VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO = 1
+} VkStructureType;
+
+typedef struct VkApplicationInfo {
+    VkStructureType sType;
+    const void *pNext;
+    const char *pApplicationName;
+    uint32_t applicationVersion;
+    const char *pEngineName;
+    uint32_t engineVersion;
+    uint32_t apiVersion;
+} VkApplicationInfo;
+
+typedef struct VkInstanceCreateInfo {
+    VkStructureType sType;
+    const void *pNext;
+    VkInstanceCreateFlags flags;
+    const VkApplicationInfo *pApplicationInfo;
+    uint32_t enabledLayerCount;
+    const char *const *ppEnabledLayerNames;
+    uint32_t enabledExtensionCount;
+    const char *const *ppEnabledExtensionNames;
+} VkInstanceCreateInfo;
+
+static inline uint32_t VulkanMinimalMakeVersion(uint32_t major, uint32_t minor, uint32_t patch) {
+    return (major << 22) | (minor << 12) | patch;
+}
+
+#define VK_SUCCESS 0
+#define VK_ERROR_INITIALIZATION_FAILED -3
+#define VK_API_VERSION_1_0 VulkanMinimalMakeVersion(1, 0, 0)
+
+VkResult VulkanMinimalCreateInstance(VulkanMinimalInstance *instance);
+void VulkanMinimalDestroyInstance(VulkanMinimalInstance *instance);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // SDLKIT_VULKAN_MINIMAL_H


### PR DESCRIPTION
## Summary
- add a VulkanMinimal helper that bootstraps a minimal VkInstance using dynamic loading so Linux builds can validate SDL-created surfaces
- update the SDLKitDemo entry point to support platform-specific native handle logging with graceful HEADLESS_CI and cleanup paths
- wire the helper target into Package.swift while keeping the existing drawing showcase for the acceptance smoke test

## Testing
- `swift build`


------
https://chatgpt.com/codex/tasks/task_b_68dc0a020e188333a7808f029c52773c