### PR TITLE
Add stub render backend and triangle demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,13 @@ let windowId = try agent.openWindow(title: "SDLKit", width: 800, height: 600)
 agent.closeWindow(windowId: windowId)
 ```
 
-### Demo (macOS)
+### Triangle Demo (Metal/D3D12/Vulkan)
 
 - Run: `swift run SDLKitDemo`
-- Shows clear, rectangle, line, circle; attempts text if SDL_ttf is available. To enable autolink for text, the demo depends on `SDLKitTTF`.
+- By default the app opens a window, selects the platform backend (Metal on macOS, D3D12 on Windows, Vulkan on Linux), uploads a static triangle, and walks a `beginFrame → draw → endFrame` loop using the new `RenderBackend` protocol.
+- Override the backend with `SDLKIT_RENDER_BACKEND=metal|d3d12|vulkan swift run SDLKitDemo` (useful for testing platform shims).
+- Force the legacy 2D smoke test instead of the triangle with `SDLKIT_DEMO_FORCE_2D=1 swift run SDLKitDemo`.
+- The previous rectangle/line/circle/text showcase still runs in legacy mode and continues to honor SDL_ttf availability.
 
 ## Agent Contract
 

--- a/Sources/SDLKit/Graphics/BackendFactory.swift
+++ b/Sources/SDLKit/Graphics/BackendFactory.swift
@@ -1,0 +1,306 @@
+import Foundation
+
+@MainActor
+final class StubRenderBackendCore {
+    enum Kind: String {
+        case metal
+        case d3d12
+        case vulkan
+
+        var label: String {
+            switch self {
+            case .metal: return "Metal"
+            case .d3d12: return "D3D12"
+            case .vulkan: return "Vulkan"
+            }
+        }
+    }
+
+    struct BufferResource {
+        var data: Data
+        var usage: BufferUsage
+    }
+
+    struct TextureResource {
+        var descriptor: TextureDescriptor
+        var data: TextureInitialData?
+    }
+
+    struct PipelineResource {
+        var descriptor: GraphicsPipelineDescriptor
+    }
+
+    struct ComputePipelineResource {
+        var descriptor: ComputePipelineDescriptor
+    }
+
+    struct MeshResource {
+        var vertexBuffer: BufferHandle
+        var vertexCount: Int
+    }
+
+    private let kind: Kind
+    private let surface: RenderSurface
+    private(set) var currentSize: (width: Int, height: Int)
+    private var buffers: [BufferHandle: BufferResource] = [:]
+    private var textures: [TextureHandle: TextureResource] = [:]
+    private var pipelines: [PipelineHandle: PipelineResource] = [:]
+    private var computePipelines: [ComputePipelineHandle: ComputePipelineResource] = [:]
+    private var meshes: [MeshHandle: MeshResource] = [:]
+    private var frameActive = false
+
+    init(kind: Kind, window: SDLWindow) throws {
+        self.kind = kind
+        self.surface = try RenderSurface(window: window)
+        self.currentSize = (width: window.config.width, height: window.config.height)
+        SDLLogger.info("SDLKit.Graphics", "Initialized stub \(kind.label) backend")
+        logSurface()
+    }
+
+    private func logSurface() {
+        #if canImport(QuartzCore)
+        if let layer = surface.metalLayer {
+            SDLLogger.debug("SDLKit.Graphics", "Surface metalLayer=\(layer)")
+        }
+        #endif
+        if let hwnd = surface.win32HWND {
+            SDLLogger.debug("SDLKit.Graphics", String(format: "Surface HWND=0x%016llX", UInt64(UInt(bitPattern: hwnd))))
+        }
+    }
+
+    func register(mesh handle: MeshHandle, vertexBuffer: BufferHandle, vertexCount: Int) {
+        meshes[handle] = MeshResource(vertexBuffer: vertexBuffer, vertexCount: vertexCount)
+    }
+
+    func beginFrame() throws {
+        guard !frameActive else {
+            throw AgentError.internalError("beginFrame called twice without endFrame")
+        }
+        frameActive = true
+        SDLLogger.debug("SDLKit.Graphics", "beginFrame on \(kind.label)")
+    }
+
+    func endFrame() throws {
+        guard frameActive else {
+            throw AgentError.internalError("endFrame called without beginFrame")
+        }
+        frameActive = false
+        SDLLogger.debug("SDLKit.Graphics", "endFrame on \(kind.label)")
+    }
+
+    func resize(width: Int, height: Int) {
+        currentSize = (width, height)
+        SDLLogger.info("SDLKit.Graphics", "resize => \(width)x\(height) on \(kind.label)")
+    }
+
+    func waitGPU() {
+        SDLLogger.debug("SDLKit.Graphics", "waitGPU on \(kind.label)")
+    }
+
+    func createBuffer(bytes: UnsafeRawPointer?, length: Int, usage: BufferUsage) -> BufferHandle {
+        var data = Data()
+        if let bytes, length > 0 {
+            data = Data(bytes: bytes, count: length)
+        }
+        let handle = BufferHandle()
+        buffers[handle] = BufferResource(data: data, usage: usage)
+        SDLLogger.debug("SDLKit.Graphics", "createBuffer id=\(handle.rawValue) bytes=\(length) usage=\(usage)")
+        return handle
+    }
+
+    func createTexture(descriptor: TextureDescriptor, initialData: TextureInitialData?) -> TextureHandle {
+        let handle = TextureHandle()
+        textures[handle] = TextureResource(descriptor: descriptor, data: initialData)
+        SDLLogger.debug("SDLKit.Graphics", "createTexture id=\(handle.rawValue) size=\(descriptor.width)x\(descriptor.height) format=\(descriptor.format.rawValue)")
+        return handle
+    }
+
+    func destroy(_ handle: ResourceHandle) {
+        switch handle {
+        case .buffer(let h):
+            buffers.removeValue(forKey: h)
+        case .texture(let h):
+            textures.removeValue(forKey: h)
+        case .pipeline(let h):
+            pipelines.removeValue(forKey: h)
+        case .computePipeline(let h):
+            computePipelines.removeValue(forKey: h)
+        case .mesh(let h):
+            meshes.removeValue(forKey: h)
+        }
+        SDLLogger.debug("SDLKit.Graphics", "destroy handle=\(handle)")
+    }
+
+    func makePipeline(_ desc: GraphicsPipelineDescriptor) -> PipelineHandle {
+        let handle = PipelineHandle()
+        pipelines[handle] = PipelineResource(descriptor: desc)
+        SDLLogger.debug("SDLKit.Graphics", "makePipeline id=\(handle.rawValue) label=\(desc.label ?? "<nil>")")
+        return handle
+    }
+
+    func draw(mesh: MeshHandle,
+              pipeline: PipelineHandle,
+              bindings: BindingSet,
+              pushConstants: UnsafeRawPointer?,
+              transform: float4x4) throws {
+        guard frameActive else {
+            throw AgentError.internalError("draw called outside beginFrame/endFrame")
+        }
+        guard pipelines[pipeline] != nil else {
+            throw AgentError.internalError("Unknown pipeline for draw call")
+        }
+        let meshResource = meshes[mesh]
+        SDLLogger.debug("SDLKit.Graphics", "draw mesh=\(mesh.rawValue) pipeline=\(pipeline.rawValue) vertexBuffer=\(meshResource?.vertexBuffer.rawValue ?? 0) vertexCount=\(meshResource?.vertexCount ?? 0)")
+        _ = bindings
+        _ = pushConstants
+        _ = transform
+    }
+
+    func makeComputePipeline(_ desc: ComputePipelineDescriptor) -> ComputePipelineHandle {
+        let handle = ComputePipelineHandle()
+        computePipelines[handle] = ComputePipelineResource(descriptor: desc)
+        SDLLogger.debug("SDLKit.Graphics", "makeComputePipeline id=\(handle.rawValue) label=\(desc.label ?? "<nil>")")
+        return handle
+    }
+
+    func dispatchCompute(_ pipeline: ComputePipelineHandle,
+                         groupsX: Int, groupsY: Int, groupsZ: Int,
+                         bindings: BindingSet,
+                         pushConstants: UnsafeRawPointer?) throws {
+        guard computePipelines[pipeline] != nil else {
+            throw AgentError.internalError("Unknown compute pipeline")
+        }
+        SDLLogger.debug("SDLKit.Graphics", "dispatchCompute pipeline=\(pipeline.rawValue) groups=(\(groupsX),\(groupsY),\(groupsZ))")
+        _ = bindings
+        _ = pushConstants
+    }
+}
+
+@MainActor
+public class StubRenderBackend: RenderBackend {
+    fileprivate let core: StubRenderBackendCore
+
+    fileprivate init(kind: StubRenderBackendCore.Kind, window: SDLWindow) throws {
+        self.core = try StubRenderBackendCore(kind: kind, window: window)
+    }
+
+    required public init(window: SDLWindow) throws {
+        fatalError("Use specialized subclass initializers")
+    }
+
+    public func beginFrame() throws { try core.beginFrame() }
+    public func endFrame() throws { try core.endFrame() }
+    public func resize(width: Int, height: Int) throws { core.resize(width: width, height: height) }
+    public func waitGPU() throws { core.waitGPU() }
+    public func createBuffer(bytes: UnsafeRawPointer?, length: Int, usage: BufferUsage) throws -> BufferHandle { core.createBuffer(bytes: bytes, length: length, usage: usage) }
+    public func createTexture(descriptor: TextureDescriptor, initialData: TextureInitialData?) throws -> TextureHandle { core.createTexture(descriptor: descriptor, initialData: initialData) }
+    public func destroy(_ handle: ResourceHandle) { core.destroy(handle) }
+    public func makePipeline(_ desc: GraphicsPipelineDescriptor) throws -> PipelineHandle { core.makePipeline(desc) }
+    public func draw(mesh: MeshHandle, pipeline: PipelineHandle, bindings: BindingSet, pushConstants: UnsafeRawPointer?, transform: float4x4) throws { try core.draw(mesh: mesh, pipeline: pipeline, bindings: bindings, pushConstants: pushConstants, transform: transform) }
+    public func makeComputePipeline(_ desc: ComputePipelineDescriptor) throws -> ComputePipelineHandle { core.makeComputePipeline(desc) }
+    public func dispatchCompute(_ pipeline: ComputePipelineHandle, groupsX: Int, groupsY: Int, groupsZ: Int, bindings: BindingSet, pushConstants: UnsafeRawPointer?) throws { try core.dispatchCompute(pipeline, groupsX: groupsX, groupsY: groupsY, groupsZ: groupsZ, bindings: bindings, pushConstants: pushConstants) }
+
+    public func register(mesh handle: MeshHandle, vertexBuffer: BufferHandle, vertexCount: Int) {
+        core.register(mesh: handle, vertexBuffer: vertexBuffer, vertexCount: vertexCount)
+    }
+}
+
+@MainActor
+public final class MetalRenderBackend: StubRenderBackend {
+    required public init(window: SDLWindow) throws {
+        try super.init(kind: .metal, window: window)
+    }
+}
+
+@MainActor
+public final class D3D12RenderBackend: StubRenderBackend {
+    required public init(window: SDLWindow) throws {
+        try super.init(kind: .d3d12, window: window)
+    }
+}
+
+@MainActor
+public final class VulkanRenderBackend: StubRenderBackend {
+    required public init(window: SDLWindow) throws {
+        try super.init(kind: .vulkan, window: window)
+    }
+}
+
+@MainActor
+public enum RenderBackendFactory {
+    public enum Choice: String {
+        case metal
+        case d3d12
+        case vulkan
+
+        static func parse(_ raw: String) -> Choice? {
+            let value = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            switch value {
+            case "metal", "mtl": return .metal
+            case "d3d12", "direct3d", "dx12": return .d3d12
+            case "vulkan", "vk": return .vulkan
+            default: return nil
+            }
+        }
+    }
+
+    public static func defaultChoice() -> Choice {
+        #if os(macOS)
+        return .metal
+        #elseif os(Windows)
+        return .d3d12
+        #elseif os(Linux)
+        return .vulkan
+        #else
+        return .metal
+        #endif
+    }
+
+    public static func makeBackend(window: SDLWindow, override: String? = nil) throws -> RenderBackend {
+        let overrideValue = override ?? SDLKitConfig.renderBackendOverride
+        let choice: Choice
+        if let overrideValue {
+            guard let parsed = Choice.parse(overrideValue) else {
+                throw AgentError.invalidArgument("Unknown render backend override: \(overrideValue)")
+            }
+            choice = parsed
+        } else {
+            choice = defaultChoice()
+        }
+        if !isChoiceSupported(choice) {
+            throw AgentError.invalidArgument("Render backend \(choice.rawValue) not supported on this platform")
+        }
+        SDLLogger.info("SDLKit.Graphics", "RenderBackendFactory => \(choice.rawValue)")
+        switch choice {
+        case .metal:
+            return try MetalRenderBackend(window: window)
+        case .d3d12:
+            return try D3D12RenderBackend(window: window)
+        case .vulkan:
+            return try VulkanRenderBackend(window: window)
+        }
+    }
+
+    private static func isChoiceSupported(_ choice: Choice) -> Bool {
+        switch choice {
+        case .metal:
+            #if os(macOS)
+            return true
+            #else
+            return false
+            #endif
+        case .d3d12:
+            #if os(Windows)
+            return true
+            #else
+            return false
+            #endif
+        case .vulkan:
+            #if os(Linux)
+            return true
+            #else
+            return false
+            #endif
+        }
+    }
+}

--- a/Sources/SDLKit/Graphics/RenderBackend.swift
+++ b/Sources/SDLKit/Graphics/RenderBackend.swift
@@ -1,0 +1,236 @@
+import Foundation
+
+public struct float4x4 {
+    public typealias Column = (Float, Float, Float, Float)
+    public var columns: (Column, Column, Column, Column)
+    public init(_ c0: Column, _ c1: Column, _ c2: Column, _ c3: Column) {
+        self.columns = (c0, c1, c2, c3)
+    }
+
+    public init() {
+        self.init(
+            (1, 0, 0, 0),
+            (0, 1, 0, 0),
+            (0, 0, 1, 0),
+            (0, 0, 0, 1)
+        )
+    }
+
+    public static var identity: float4x4 { float4x4() }
+}
+
+public struct ShaderID: Hashable, Codable {
+    public let rawValue: String
+    public init(_ rawValue: String) { self.rawValue = rawValue }
+}
+
+public struct BufferHandle: Hashable, Codable {
+    public let rawValue: UInt64
+    public init() { self.init(rawValue: UInt64.random(in: UInt64.min...UInt64.max)) }
+    public init(rawValue: UInt64) { self.rawValue = rawValue }
+}
+
+public struct TextureHandle: Hashable, Codable {
+    public let rawValue: UInt64
+    public init() { self.init(rawValue: UInt64.random(in: UInt64.min...UInt64.max)) }
+    public init(rawValue: UInt64) { self.rawValue = rawValue }
+}
+
+public struct PipelineHandle: Hashable, Codable {
+    public let rawValue: UInt64
+    public init() { self.init(rawValue: UInt64.random(in: UInt64.min...UInt64.max)) }
+    public init(rawValue: UInt64) { self.rawValue = rawValue }
+}
+
+public struct ComputePipelineHandle: Hashable, Codable {
+    public let rawValue: UInt64
+    public init() { self.init(rawValue: UInt64.random(in: UInt64.min...UInt64.max)) }
+    public init(rawValue: UInt64) { self.rawValue = rawValue }
+}
+
+public struct MeshHandle: Hashable, Codable {
+    public let rawValue: UInt64
+    public init() { self.init(rawValue: UInt64.random(in: UInt64.min...UInt64.max)) }
+    public init(rawValue: UInt64) { self.rawValue = rawValue }
+}
+
+public enum BufferUsage {
+    case vertex
+    case index
+    case uniform
+    case storage
+    case staging
+}
+
+public enum TextureFormat: String, Codable {
+    case rgba8Unorm
+    case bgra8Unorm
+    case depth32Float
+}
+
+public struct TextureDescriptor {
+    public var width: Int
+    public var height: Int
+    public var mipLevels: Int
+    public var format: TextureFormat
+    public var usage: TextureUsage
+    public init(width: Int, height: Int, mipLevels: Int = 1, format: TextureFormat, usage: TextureUsage) {
+        self.width = width
+        self.height = height
+        self.mipLevels = mipLevels
+        self.format = format
+        self.usage = usage
+    }
+}
+
+public struct TextureInitialData {
+    public var mipLevelData: [Data]
+    public init(mipLevelData: [Data] = []) { self.mipLevelData = mipLevelData }
+}
+
+public struct VertexLayout {
+    public struct Attribute {
+        public var index: Int
+        public var semantic: String
+        public var format: VertexFormat
+        public var offset: Int
+        public init(index: Int, semantic: String, format: VertexFormat, offset: Int) {
+            self.index = index
+            self.semantic = semantic
+            self.format = format
+            self.offset = offset
+        }
+    }
+    public var stride: Int
+    public var attributes: [Attribute]
+    public init(stride: Int, attributes: [Attribute]) {
+        self.stride = stride
+        self.attributes = attributes
+    }
+}
+
+public enum VertexFormat {
+    case float2
+    case float3
+    case float4
+}
+
+public enum ShaderStage {
+    case vertex
+    case fragment
+    case compute
+}
+
+public struct BindingSlot {
+    public let index: Int
+    public let kind: Kind
+    public init(index: Int, kind: Kind) {
+        self.index = index
+        self.kind = kind
+    }
+
+    public enum Kind {
+        case uniformBuffer
+        case storageBuffer
+        case sampledTexture
+        case storageTexture
+        case sampler
+    }
+}
+
+public struct BindingSet {
+    public var slots: [Int: Any]
+    public init(slots: [Int: Any] = [:]) { self.slots = slots }
+    public mutating func setValue(_ value: Any, for index: Int) { slots[index] = value }
+    public func value<T>(for index: Int, as type: T.Type) -> T? { slots[index] as? T }
+}
+
+public enum TextureUsage {
+    case shaderRead
+    case shaderWrite
+    case renderTarget
+    case depthStencil
+}
+
+public struct GraphicsPipelineDescriptor {
+    public var label: String?
+    public var vertexShader: ShaderID
+    public var fragmentShader: ShaderID?
+    public var vertexLayout: VertexLayout
+    public var colorFormats: [TextureFormat]
+    public var depthFormat: TextureFormat?
+    public var sampleCount: Int
+    public init(label: String? = nil,
+                vertexShader: ShaderID,
+                fragmentShader: ShaderID?,
+                vertexLayout: VertexLayout,
+                colorFormats: [TextureFormat],
+                depthFormat: TextureFormat? = nil,
+                sampleCount: Int = 1) {
+        self.label = label
+        self.vertexShader = vertexShader
+        self.fragmentShader = fragmentShader
+        self.vertexLayout = vertexLayout
+        self.colorFormats = colorFormats
+        self.depthFormat = depthFormat
+        self.sampleCount = sampleCount
+    }
+}
+
+public struct ComputePipelineDescriptor {
+    public var label: String?
+    public var shader: ShaderID
+    public init(label: String? = nil, shader: ShaderID) {
+        self.label = label
+        self.shader = shader
+    }
+}
+
+public enum ResourceHandle: Hashable {
+    case buffer(BufferHandle)
+    case texture(TextureHandle)
+    case pipeline(PipelineHandle)
+    case computePipeline(ComputePipelineHandle)
+    case mesh(MeshHandle)
+}
+
+@MainActor
+public struct RenderSurface {
+    public let window: SDLWindow
+    public let handles: SDLWindow.NativeHandles
+    public init(window: SDLWindow) throws {
+        self.window = window
+        self.handles = try window.nativeHandles()
+    }
+    public var metalLayer: SDLKitMetalLayer? { handles.metalLayer }
+    public var win32HWND: UnsafeMutableRawPointer? { handles.win32HWND }
+    public func createVulkanSurface(instance: VkInstance) throws -> VkSurfaceKHR {
+        try handles.createVulkanSurface(instance: instance)
+    }
+}
+
+@MainActor
+public protocol RenderBackend {
+    init(window: SDLWindow) throws
+    func beginFrame() throws
+    func endFrame() throws
+    func resize(width: Int, height: Int) throws
+    func waitGPU() throws
+
+    func createBuffer(bytes: UnsafeRawPointer?, length: Int, usage: BufferUsage) throws -> BufferHandle
+    func createTexture(descriptor: TextureDescriptor, initialData: TextureInitialData?) throws -> TextureHandle
+    func destroy(_ handle: ResourceHandle)
+
+    func makePipeline(_ desc: GraphicsPipelineDescriptor) throws -> PipelineHandle
+    func draw(mesh: MeshHandle,
+              pipeline: PipelineHandle,
+              bindings: BindingSet,
+              pushConstants: UnsafeRawPointer?,
+              transform: float4x4) throws
+
+    func makeComputePipeline(_ desc: ComputePipelineDescriptor) throws -> ComputePipelineHandle
+    func dispatchCompute(_ pipeline: ComputePipelineHandle,
+                         groupsX: Int, groupsY: Int, groupsZ: Int,
+                         bindings: BindingSet,
+                         pushConstants: UnsafeRawPointer?) throws
+}

--- a/Sources/SDLKit/SDLKit.swift
+++ b/Sources/SDLKit/SDLKit.swift
@@ -28,6 +28,22 @@ public enum SDLKitConfig {
         return parsed
     }
 
+    public static var renderBackendOverride: String? {
+        guard let raw = ProcessInfo.processInfo.environment["SDLKIT_RENDER_BACKEND"] else {
+            return nil
+        }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    public static var demoForceLegacy2D: Bool {
+        guard let raw = ProcessInfo.processInfo.environment["SDLKIT_DEMO_FORCE_2D"] else {
+            return false
+        }
+        let value = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return value == "1" || value == "true" || value == "yes"
+    }
+
     public enum PresentPolicy { case auto, explicit }
 }
 

--- a/Sources/SDLKitDemo/main.swift
+++ b/Sources/SDLKitDemo/main.swift
@@ -27,8 +27,6 @@ struct DemoApp {
         case linux
     }
 
-    private struct ExitSignal: Error {}
-
     static func main() {
         guard SDLKitConfig.guiEnabled else {
             print("GUI disabled. Set SDLKIT_GUI_ENABLED=1 to enable.")
@@ -49,8 +47,6 @@ struct DemoApp {
         do {
             try runDemo(on: platform, agent: agent)
             print("SDLKitDemo: completed smoke test for \(platform.rawValue)")
-        } catch is ExitSignal {
-            print("SDLKitDemo: user exit")
         } catch AgentError.sdlUnavailable {
             print("SDL unavailable on this build. Install SDL3 to run the demo.")
         } catch {
@@ -60,6 +56,21 @@ struct DemoApp {
 
     @MainActor
     private static func runDemo(on platform: DemoPlatform, agent: SDLKitGUIAgent) throws {
+        if SDLKitConfig.demoForceLegacy2D {
+            try runLegacy2DDemo(on: platform, agent: agent)
+            return
+        }
+
+        do {
+            try runTriangleDemo(on: platform)
+        } catch {
+            print("Triangle demo failed (\(error)); falling back to legacy 2D showcase")
+            try runLegacy2DDemo(on: platform, agent: agent)
+        }
+    }
+
+    @MainActor
+    private static func runLegacy2DDemo(on platform: DemoPlatform, agent: SDLKitGUIAgent) throws {
         let windowId = try agent.openWindow(title: "SDLKit Demo", width: 640, height: 480)
         defer { agent.closeWindow(windowId: windowId) }
 
@@ -68,33 +79,8 @@ struct DemoApp {
 
         let start = Date()
         while Date().timeIntervalSince(start) < 2.0 {
-            if let event = try agent.captureEvent(windowId: windowId, timeoutMs: 100) {
-                switch event.type {
-                case .quit, .windowClosed, .keyDown, .mouseDown:
-                    throw ExitSignal()
-                default:
-                    break
-                }
-            }
+            _ = try agent.captureEvent(windowId: windowId, timeoutMs: 100)
         }
-    }
-
-    @MainActor
-    private static func showcaseDrawing(windowId: Int, agent: SDLKitGUIAgent) throws {
-        try agent.clear(windowId: windowId, color: "#0F0F13")
-        try agent.drawRectangle(windowId: windowId, x: 40, y: 40, width: 200, height: 120, color: "#3366FF")
-        try agent.drawLine(windowId: windowId, x1: 0, y1: 0, x2: 639, y2: 479, color: "#FFCC00")
-        try agent.drawCircleFilled(windowId: windowId, cx: 320, cy: 240, radius: 60, color: "#55FFAA")
-        #if canImport(SDLKitTTF)
-        do {
-            try agent.drawText(windowId: windowId, text: "SDLKit ✓", x: 20, y: 200, font: "/System/Library/Fonts/Supplemental/Arial Unicode.ttf", size: 22, color: 0xFFFFFFFF)
-        } catch AgentError.notImplemented {
-            print("SDL_ttf not available; skipping text rendering")
-        } catch {
-            print("Text draw error: \(error)")
-        }
-        #endif
-        try agent.present(windowId: windowId)
     }
 
     @MainActor
@@ -142,6 +128,146 @@ struct DemoApp {
             let surface = try handles.createVulkanSurface(instance: vkInstance)
             let formattedSurface = String(format: "0x%016llX", UInt64(surface))
             print("SDLKitDemo: Vulkan surface => \(formattedSurface)")
+            #else
+            print("SDLKitDemo: Vulkan headers unavailable; skipping surface creation")
+            #endif
+        }
+    }
+
+    @MainActor
+    private static func runTriangleDemo(on platform: DemoPlatform) throws {
+        let window = SDLWindow(config: .init(title: "SDLKit Triangle", width: 640, height: 480))
+        try window.open()
+        defer { window.close() }
+        try window.show()
+
+        let backend = try RenderBackendFactory.makeBackend(window: window)
+        defer { try? backend.waitGPU() }
+
+        let surface = try RenderSurface(window: window)
+        logNativeHandles(for: platform, surface: surface)
+
+        struct Vertex {
+            var position: (Float, Float, Float)
+            var color: (Float, Float, Float)
+        }
+
+        let vertices: [Vertex] = [
+            Vertex(position: (-0.6, -0.5, 0), color: (1, 0, 0)),
+            Vertex(position: (0.0, 0.6, 0), color: (0, 1, 0)),
+            Vertex(position: (0.6, -0.5, 0), color: (0, 0, 1))
+        ]
+
+        let vertexBuffer = try vertices.withUnsafeBytes { buffer -> BufferHandle in
+            try backend.createBuffer(bytes: buffer.baseAddress, length: buffer.count, usage: .vertex)
+        }
+
+        let mesh = MeshHandle()
+        if let stub = backend as? StubRenderBackend {
+            stub.register(mesh: mesh, vertexBuffer: vertexBuffer, vertexCount: vertices.count)
+        }
+
+        let stride = MemoryLayout<Vertex>.stride
+        let colorOffset = MemoryLayout<Vertex>.offset(of: \.color) ?? MemoryLayout<(Float, Float, Float)>.stride
+        let vertexLayout = VertexLayout(
+            stride: stride,
+            attributes: [
+                .init(index: 0, semantic: "POSITION", format: .float3, offset: 0),
+                .init(index: 1, semantic: "COLOR", format: .float3, offset: colorOffset)
+            ]
+        )
+
+        let pipeline = try backend.makePipeline(
+            GraphicsPipelineDescriptor(
+                label: "unlit_triangle",
+                vertexShader: ShaderID("unlit_triangle_vs"),
+                fragmentShader: ShaderID("unlit_triangle_fs"),
+                vertexLayout: vertexLayout,
+                colorFormats: [.bgra8Unorm]
+            )
+        )
+
+        for _ in 0..<3 {
+            try backend.beginFrame()
+            let bindings = BindingSet(slots: [0: vertexBuffer])
+            try backend.draw(
+                mesh: mesh,
+                pipeline: pipeline,
+                bindings: bindings,
+                pushConstants: nil,
+                transform: float4x4.identity
+            )
+            try backend.endFrame()
+            Thread.sleep(forTimeInterval: 1.0 / 30.0)
+        }
+    }
+
+    @MainActor
+    private static func showcaseDrawing(windowId: Int, agent: SDLKitGUIAgent) throws {
+        try agent.clear(windowId: windowId, color: "#0F0F13")
+        try agent.drawRectangle(windowId: windowId, x: 40, y: 40, width: 200, height: 120, color: "#3366FF")
+        try agent.drawLine(windowId: windowId, x1: 0, y1: 0, x2: 639, y2: 479, color: "#FFCC00")
+        try agent.drawCircleFilled(windowId: windowId, cx: 320, cy: 240, radius: 60, color: "#55FFAA")
+        #if canImport(SDLKitTTF)
+        do {
+            try agent.drawText(windowId: windowId, text: "SDLKit ✓", x: 20, y: 200, font: "/System/Library/Fonts/Supplemental/Arial Unicode.ttf", size: 22, color: 0xFFFFFFFF)
+        } catch AgentError.notImplemented {
+            print("SDL_ttf not available; skipping text rendering")
+        } catch {
+            print("Text draw error: \(error)")
+        }
+        #endif
+        try agent.present(windowId: windowId)
+    }
+
+    @MainActor
+    private static func logNativeHandles(for platform: DemoPlatform, surface: RenderSurface) {
+        switch platform {
+        case .macOS:
+            #if canImport(QuartzCore)
+            if let layer = surface.metalLayer as? CAMetalLayer {
+                let nameDescription: String
+                if let name = layer.name {
+                    if let stringName = name as? String {
+                        nameDescription = stringName
+                    } else {
+                        nameDescription = String(describing: name)
+                    }
+                } else {
+                    nameDescription = "nil"
+                }
+                print("SDLKitDemo: CAMetalLayer => class=\(String(describing: type(of: layer))) name=\(nameDescription)")
+            } else {
+                print("SDLKitDemo: CAMetalLayer unavailable on macOS")
+            }
+            #else
+            print("SDLKitDemo: QuartzCore unavailable on this build")
+            #endif
+        case .windows:
+            if let hwnd = surface.win32HWND {
+                let value = UInt(bitPattern: hwnd)
+                let formatted = String(format: "0x%016llX", UInt64(value))
+                print("SDLKitDemo: Win32 HWND => \(formatted)")
+            } else {
+                print("SDLKitDemo: Win32 HWND unavailable")
+            }
+        case .linux:
+            #if canImport(VulkanMinimal)
+            var instance = VulkanMinimalInstance()
+            let result = VulkanMinimalCreateInstance(&instance)
+            guard result == VK_SUCCESS, let vkInstance = instance.handle else {
+                print("SDLKitDemo: Vulkan instance creation failed (code=\(result))")
+                VulkanMinimalDestroyInstance(&instance)
+                return
+            }
+            defer { VulkanMinimalDestroyInstance(&instance) }
+            do {
+                let surfaceHandle = try surface.createVulkanSurface(instance: vkInstance)
+                let formattedSurface = String(format: "0x%016llX", UInt64(surfaceHandle))
+                print("SDLKitDemo: Vulkan surface => \(formattedSurface)")
+            } catch {
+                print("SDLKitDemo: Vulkan surface creation failed: \(error)")
+            }
             #else
             print("SDLKitDemo: Vulkan headers unavailable; skipping surface creation")
             #endif


### PR DESCRIPTION
## Summary
- add the RenderBackend protocol and shared handle/descriptor types used by the graphics stack
- stub Metal/D3D12/Vulkan backend factory that records resources and exposes logging hooks
- update SDLKitDemo to drive a triangle demo with a configurable legacy 2D fallback and document the new flow

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68dc0f3529c483338038d8dc623ce63d