### PR TITLE
Add persistent mesh registration and caching

### DIFF
--- a/Sources/SDLKit/Graphics/RenderBackend.swift
+++ b/Sources/SDLKit/Graphics/RenderBackend.swift
@@ -230,6 +230,12 @@ public protocol RenderBackend {
     func createTexture(descriptor: TextureDescriptor, initialData: TextureInitialData?) throws -> TextureHandle
     func destroy(_ handle: ResourceHandle)
 
+    func registerMesh(vertexBuffer: BufferHandle,
+                      vertexCount: Int,
+                      indexBuffer: BufferHandle?,
+                      indexCount: Int,
+                      indexFormat: IndexFormat) throws -> MeshHandle
+
     func makePipeline(_ desc: GraphicsPipelineDescriptor) throws -> PipelineHandle
     func draw(mesh: MeshHandle,
               pipeline: PipelineHandle,

--- a/Sources/SDLKitDemo/main.swift
+++ b/Sources/SDLKitDemo/main.swift
@@ -162,10 +162,13 @@ struct DemoApp {
             try backend.createBuffer(bytes: buffer.baseAddress, length: buffer.count, usage: .vertex)
         }
 
-        let mesh = MeshHandle()
-        if let stub = backend as? StubRenderBackend {
-            stub.register(mesh: mesh, vertexBuffer: vertexBuffer, vertexCount: vertices.count)
-        }
+        let mesh = try backend.registerMesh(
+            vertexBuffer: vertexBuffer,
+            vertexCount: vertices.count,
+            indexBuffer: nil,
+            indexCount: 0,
+            indexFormat: .uint16
+        )
 
         let shaderModule = try ShaderLibrary.shared.module(for: ShaderID("unlit_triangle"))
         let vertexLayout = shaderModule.vertexLayout
@@ -181,7 +184,7 @@ struct DemoApp {
 
         for _ in 0..<3 {
             try backend.beginFrame()
-            let bindings = BindingSet(slots: [0: vertexBuffer])
+            let bindings = BindingSet()
             try backend.draw(
                 mesh: mesh,
                 pipeline: pipeline,


### PR DESCRIPTION
## Summary
- add a mesh registration API to `RenderBackend` and cache registrations on `SceneGraph.Mesh`
- track vertex and index buffer pairs by `MeshHandle` in the stub, Metal, D3D12, and Vulkan backends
- update the demo to request mesh handles via the registration path before drawing

## Testing
- swift build

------
https://chatgpt.com/codex/tasks/task_b_68dcbe38b060833392f9b6256f5a633a