### PR TITLE
docs: split long guides into dedicated docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,67 @@
+# Installation Guide
+
+SDLKit builds on the Fountain‑Coach SDL3 fork and discovers the library via `pkg-config`. This guide aggregates the steps for fetching the fork, pointing SwiftPM at custom prefixes, and verifying your environment before you begin development.
+
+## Use the Fountain‑Coach SDL3 fork
+
+SDLKit is designed to track the Fountain‑Coach fork of SDL3.
+
+- Repository: <https://github.com/Fountain-Coach/SDL>
+- Follow that repository's instructions to build or install SDL3 for your platform.
+- SDLKit consumes the library through the `sdl3` `pkg-config` module and links `SDL3` automatically.
+
+When installing to a nonstandard prefix, expose the locations so SwiftPM can forward include and library paths:
+
+- `SDL3_INCLUDE_DIR` — SDL headers (for example `/opt/sdl/include`).
+- `SDL3_LIB_DIR` — SDL libraries (for example `/opt/sdl/lib`).
+
+These environment variables are read by `Package.swift` to emit the correct `-I`/`-L` flags.
+
+## Platform-specific install instructions
+
+### macOS
+
+```bash
+brew install sdl3
+```
+
+You can also build the Fountain‑Coach fork from source when you need its bleeding-edge features.
+
+### Linux (Debian/Ubuntu)
+
+```bash
+sudo apt-get install -y libsdl3-dev
+```
+
+Alternatively, build and install the fork manually, then export `PKG_CONFIG_PATH` so `pkg-config` finds the resulting `.pc` file.
+
+### Windows
+
+Install SDL3 via vcpkg:
+
+```powershell
+vcpkg install sdl3
+```
+
+Ensure the resulting headers and libraries are visible to your Swift toolchain. When running binaries, you may need to extend `PATH`/`LD_LIBRARY_PATH` (for example `setx PATH "C:\path\to\sdl3\bin;%PATH%"`) so the loader finds `SDL3.dll`/`libSDL3.so`.
+
+### Dynamic library lookups
+
+If you install the fork under a custom prefix, export:
+
+```bash
+export LD_LIBRARY_PATH=/path/to/prefix/lib:$LD_LIBRARY_PATH
+```
+
+on Linux or set the equivalent search path on Windows and macOS. This ensures the runtime loader discovers SDL3 when you launch samples or tests.
+
+## Verify your installation
+
+After installing SDL3, run the standard SwiftPM commands to confirm your environment is ready:
+
+```bash
+swift build
+swift test
+```
+
+Headless CI builds continue to succeed even when SDL3 is absent, but installing the library locally lets you exercise the windowing and rendering paths.

--- a/docs/scenegraph.md
+++ b/docs/scenegraph.md
@@ -1,0 +1,57 @@
+# Scene Graph & Demo Guide
+
+SDLKit ships a 3D scene graph layered on top of the core SDL windowing and rendering primitives. The demo targets Metal, Direct3D 12, and Vulkan backends through the shared `RenderBackend` protocol. This guide covers how to launch the demo, override backends, and validate rendering output.
+
+## Run the demo
+
+```bash
+swift run SDLKitDemo
+```
+
+The sample opens a window, selects the platform backend (Metal on macOS, D3D12 on Windows, Vulkan on Linux), uploads a static triangle, and drives a `beginFrame → draw → endFrame` loop. It exercises the new `RenderBackend` protocol and the scene graph traversal that submits meshes every frame.
+
+## Choose a specific backend
+
+You can override the default backend selection either through the persisted settings CLI or environment variables.
+
+- Persisted: `swift run SDLKitSettings set --key render.backend.override --value metal`
+- Environment variable: `SDLKIT_RENDER_BACKEND=metal|d3d12|vulkan swift run SDLKitDemo`
+
+To force the legacy 2D smoke test instead of the 3D triangle, run:
+
+```bash
+SDLKIT_DEMO_FORCE_2D=1 swift run SDLKitDemo
+```
+
+## Golden image parity (Milestone M3)
+
+Automated validation compares rendered output to reference hashes. Enable the tests with:
+
+```bash
+SDLKIT_GOLDEN=1 swift test
+```
+
+You can also manage references directly:
+
+- Write a new reference: `swift run SDLKitGolden --backend metal --size 256x256 --material basic_lit --write`
+- Verify against the reference: `swift run SDLKitGolden --backend metal --size 256x256 --material basic_lit`
+
+## Scene graph defaults and settings
+
+The scene graph respects configuration stored under `.fountain/sdlkit` via the `SDLKitSettings` CLI.
+
+Examples:
+
+- `swift run SDLKitSettings set --key scene.default.material --value basic_lit`
+- `swift run SDLKitSettings set --key scene.default.baseColor --value "1.0,1.0,1.0,1.0"`
+- `swift run SDLKitSettings set --key scene.default.lightDirection --value "0.3,-0.5,0.8"`
+
+Use `swift run SDLKitMigrate` to port known `SDLKIT_*` environment variables into the settings store and print a JSON summary.
+
+Secrets are managed via `SDLKitSecrets` (Keychain on macOS, Secret Service on Linux, file-based fallback elsewhere). For example:
+
+```bash
+swift run SDLKitSecrets set --key light_dir --value "0.3,-0.5,0.8"
+```
+
+The demo reads `light_dir` when present to configure the default scene light direction.

--- a/docs/shader-toolchain.md
+++ b/docs/shader-toolchain.md
@@ -1,0 +1,48 @@
+# Shader Toolchain Guide
+
+SDLKit ships committed shader binaries, but the repository also contains the end-to-end toolchain so contributors can rebuild artifacts or author new shaders. This guide collects the workflow, required tooling, and verification steps that previously lived in the README.
+
+## 1. Install external tools
+
+SDLKit uses a single-source HLSL flow that targets multiple graphics APIs. Install the following utilities and expose them via your `PATH` or the documented environment variables.
+
+- **DXC** — required to compile HLSL to DXIL and SPIR-V. Configure `SDLKIT_SHADER_DXC` or ensure `dxc` is discoverable.
+- **SPIRV-Cross** *(optional)* — converts SPIR-V to MSL when native `.metal` sources are unavailable. Configure `SDLKIT_SHADER_SPIRV_CROSS`.
+- **Apple `metal` / `metallib`** *(optional, macOS)* — builds `.metallib` outputs directly. Override discovery with `SDLKIT_SHADER_METAL` and `SDLKIT_SHADER_METALLIB`.
+- **Python 3** — runs the helper script invoked by the SwiftPM plugin.
+
+You can also place tool binaries under `External/Toolchains/bin` to avoid editing your global `PATH`.
+
+## 2. Provide per-project overrides
+
+The shader build plugin reads optional `.fountain/sdlkit/shader-tools.env` files to inject environment overrides when it runs. This lets teams codify tool paths or compiler flags per repository without touching user shells.
+
+## 3. Invoke the build
+
+Building `SDLKit` automatically triggers the `ShaderBuildPlugin`, which calls:
+
+```
+Scripts/ShaderBuild/build-shaders.py <package-root> <workdir>
+```
+
+before compilation. You can also trigger the script manually:
+
+```bash
+python3 Scripts/ShaderBuild/build-shaders.py "$(pwd)" .build/shader-cache
+```
+
+The script emits DXIL, SPIR-V, and Metallib artifacts, writes optional intermediate `.msl/.air` files, and records a `shader-build.log` summary inside the working directory.
+
+## 4. Artifact layout
+
+The plugin copies final binaries into `Sources/SDLKit/Generated/{dxil,spirv,metal}`. `ShaderLibrary` loads these artifacts at runtime and exposes both graphics and compute shaders so render and compute paths share metadata.
+
+## 5. Verification
+
+Run the focused shader tests to ensure the manifest matches the committed binaries:
+
+```bash
+swift test --filter ShaderArtifactsTests
+```
+
+The tests confirm the expected files exist and align with the manifest checked into source control.


### PR DESCRIPTION
## Summary
- add docs/install.md, docs/shader-toolchain.md, and docs/scenegraph.md with detailed guides moved from the README
- replace the long-form README sections with concise summaries that link to the new documentation
- introduce a README "Documentation" section that lists each guide for quick navigation

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_b_68dcd2c8b21883339955a154df4db8e7