### PR TITLE
Metal: align push constants and bindings for alpha

### DIFF
--- a/Shaders/graphics/basic_lit.metal
+++ b/Shaders/graphics/basic_lit.metal
@@ -16,6 +16,7 @@ struct VSOut {
 struct Uniforms {
     float4x4 uMVP;
     float4   lightDir;
+    float4   baseColor;
 };
 
 vertex VSOut basic_lit_vs(VSIn in [[stage_in]], constant Uniforms& u [[buffer(1)]]) {
@@ -30,7 +31,7 @@ fragment float4 basic_lit_ps(VSOut in [[stage_in]], constant Uniforms& u [[buffe
     float3 N = normalize(in.normal);
     float3 L = normalize(u.lightDir.xyz);
     float ndotl = max(dot(N, L), 0.0);
-    float3 lit = in.color * (0.15 + 0.85 * ndotl);
-    return float4(lit, 1.0);
+    float3 lit = in.color * (0.15 + 0.85 * ndotl) * u.baseColor.rgb;
+    return float4(lit, u.baseColor.a);
 }
 

--- a/Shaders/unlit_triangle.metal
+++ b/Shaders/unlit_triangle.metal
@@ -13,6 +13,7 @@ struct VSOut {
 
 struct Uniforms {
     float4x4 uMVP;
+    float4   baseColor;
 };
 
 vertex VSOut unlit_triangle_vs(VSIn in [[stage_in]], constant Uniforms& u [[buffer(1)]]) {
@@ -22,7 +23,8 @@ vertex VSOut unlit_triangle_vs(VSIn in [[stage_in]], constant Uniforms& u [[buff
     return o;
 }
 
-fragment float4 unlit_triangle_ps(VSOut in [[stage_in]]) {
-    return float4(in.color, 1.0);
+fragment float4 unlit_triangle_ps(VSOut in [[stage_in]], constant Uniforms& u [[buffer(1)]]) {
+    float3 tinted = in.color * u.baseColor.rgb;
+    return float4(tinted, u.baseColor.a);
 }
 

--- a/Sources/SDLKitGolden/main.swift
+++ b/Sources/SDLKitGolden/main.swift
@@ -76,17 +76,21 @@ struct SDLKitGoldenCLI {
 
     static func makeScene(backend: RenderBackend, material: String, width: Int, height: Int) throws -> Scene {
         let root = SceneNode(name: "Root")
+        let tintedBaseColor: (Float, Float, Float, Float) = (0.6, 0.45, 0.9, 1.0)
         if material == "unlit" {
             struct V { var p:(Float,Float,Float); var c:(Float,Float,Float) }
             let verts:[V] = [ .init(p:(-0.6,-0.5,0),c:(1,0,0)), .init(p:(0,0.6,0),c:(0,1,0)), .init(p:(0.6,-0.5,0),c:(0,0,1)) ]
             let vb = try verts.withUnsafeBytes { try backend.createBuffer(bytes: $0.baseAddress, length: $0.count, usage: .vertex) }
             let mesh = Mesh(vertexBuffer: vb, vertexCount: verts.count)
-            let mat = Material(shader: ShaderID("unlit_triangle"), params: .init(baseColor: (1,1,1,1)))
+            let mat = Material(shader: ShaderID("unlit_triangle"), params: .init(baseColor: tintedBaseColor))
             let node = SceneNode(name: "Unlit", transform: .identity, mesh: mesh, material: mat)
             root.addChild(node)
         } else {
             let mesh = try MeshFactory.makeLitCube(backend: backend, size: 1.0)
-            let mat = Material(shader: ShaderID("basic_lit"), params: .init(lightDirection: (0.3,-0.5,0.8), baseColor: (1,1,1,1)))
+            let mat = Material(
+                shader: ShaderID("basic_lit"),
+                params: .init(lightDirection: (0.3,-0.5,0.8), baseColor: tintedBaseColor)
+            )
             let node = SceneNode(name: "Lit", transform: .identity, mesh: mesh, material: mat)
             root.addChild(node)
         }

--- a/Tests/SDLKitTests/GoldenImageTests.swift
+++ b/Tests/SDLKitTests/GoldenImageTests.swift
@@ -23,7 +23,11 @@ final class GoldenImageTests: XCTestCase {
 
             // Build a simple lit scene (cube) with fixed light & camera
             let mesh = try MeshFactory.makeLitCube(backend: backend, size: 1.2)
-            let material = Material(shader: ShaderID("basic_lit"), params: .init(lightDirection: (0.3, -0.5, 0.8), baseColor: (1,1,1,1)))
+            let tintedBaseColor: (Float, Float, Float, Float) = (0.6, 0.45, 0.9, 1.0)
+            let material = Material(
+                shader: ShaderID("basic_lit"),
+                params: .init(lightDirection: (0.3, -0.5, 0.8), baseColor: tintedBaseColor)
+            )
             let node = SceneNode(name: "Cube", transform: .identity, mesh: mesh, material: material)
             let root = SceneNode(name: "Root")
             root.addChild(node)

--- a/Tests/SDLKitTests/SceneGraphPushConstantTests.swift
+++ b/Tests/SDLKitTests/SceneGraphPushConstantTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import XCTest
+@testable import SDLKit
+
+@MainActor
+private final class RecordingRenderBackend: RenderBackend {
+    private struct BufferResource { var data: Data; var usage: BufferUsage }
+    private struct TextureResource { var descriptor: TextureDescriptor; var data: TextureInitialData? }
+    private struct MeshResource {
+        let vertexBuffer: BufferHandle
+        let vertexCount: Int
+        let indexBuffer: BufferHandle?
+        let indexCount: Int
+        let indexFormat: IndexFormat
+    }
+
+    private var buffers: [BufferHandle: BufferResource] = [:]
+    private var textures: [TextureHandle: TextureResource] = [:]
+    private var meshes: [MeshHandle: MeshResource] = [:]
+    private var pipelines: [PipelineHandle: GraphicsPipelineDescriptor] = [:]
+    private var frameActive = false
+
+    var drawCallCount = 0
+    var lastBindings: BindingSet?
+    var lastPushConstants: [Float]?
+
+    required init(window: SDLWindow) throws {
+        _ = window
+    }
+
+    func beginFrame() throws {
+        guard !frameActive else { throw AgentError.internalError("beginFrame called twice") }
+        frameActive = true
+    }
+
+    func endFrame() throws {
+        guard frameActive else { throw AgentError.internalError("endFrame without beginFrame") }
+        frameActive = false
+    }
+
+    func resize(width: Int, height: Int) throws { _ = (width, height) }
+    func waitGPU() throws {}
+
+    func createBuffer(bytes: UnsafeRawPointer?, length: Int, usage: BufferUsage) throws -> BufferHandle {
+        var data = Data()
+        if let bytes, length > 0 {
+            data = Data(bytes: bytes, count: length)
+        }
+        let handle = BufferHandle()
+        buffers[handle] = BufferResource(data: data, usage: usage)
+        return handle
+    }
+
+    func createTexture(descriptor: TextureDescriptor, initialData: TextureInitialData?) throws -> TextureHandle {
+        let handle = TextureHandle()
+        textures[handle] = TextureResource(descriptor: descriptor, data: initialData)
+        return handle
+    }
+
+    func destroy(_ handle: ResourceHandle) {
+        switch handle {
+        case .buffer(let h): buffers.removeValue(forKey: h)
+        case .texture(let h): textures.removeValue(forKey: h)
+        case .pipeline(let h): pipelines.removeValue(forKey: h)
+        case .computePipeline: break
+        case .mesh(let h): meshes.removeValue(forKey: h)
+        }
+    }
+
+    func registerMesh(vertexBuffer: BufferHandle,
+                      vertexCount: Int,
+                      indexBuffer: BufferHandle?,
+                      indexCount: Int,
+                      indexFormat: IndexFormat) throws -> MeshHandle {
+        if let existing = meshes.first(where: { (_, resource) in
+            resource.vertexBuffer == vertexBuffer &&
+            resource.vertexCount == vertexCount &&
+            resource.indexBuffer == indexBuffer &&
+            resource.indexCount == indexCount &&
+            resource.indexFormat == indexFormat
+        })?.key {
+            return existing
+        }
+        let handle = MeshHandle()
+        meshes[handle] = MeshResource(
+            vertexBuffer: vertexBuffer,
+            vertexCount: vertexCount,
+            indexBuffer: indexBuffer,
+            indexCount: indexCount,
+            indexFormat: indexFormat
+        )
+        return handle
+    }
+
+    func makePipeline(_ desc: GraphicsPipelineDescriptor) throws -> PipelineHandle {
+        let handle = PipelineHandle()
+        pipelines[handle] = desc
+        return handle
+    }
+
+    func draw(mesh: MeshHandle,
+              pipeline: PipelineHandle,
+              bindings: BindingSet,
+              pushConstants: UnsafeRawPointer?,
+              transform: float4x4) throws {
+        guard frameActive else { throw AgentError.internalError("draw outside beginFrame/endFrame") }
+        guard meshes[mesh] != nil else { throw AgentError.internalError("Unknown mesh handle") }
+        guard pipelines[pipeline] != nil else { throw AgentError.internalError("Unknown pipeline handle") }
+        _ = transform
+        drawCallCount += 1
+        lastBindings = bindings
+        if let pushConstants {
+            let ptr = pushConstants.bindMemory(to: Float.self, capacity: 24)
+            lastPushConstants = Array(UnsafeBufferPointer(start: ptr, count: 24))
+        } else {
+            lastPushConstants = nil
+        }
+    }
+
+    func makeComputePipeline(_ desc: ComputePipelineDescriptor) throws -> ComputePipelineHandle {
+        _ = desc
+        throw AgentError.notImplemented
+    }
+
+    func dispatchCompute(_ pipeline: ComputePipelineHandle,
+                         groupsX: Int,
+                         groupsY: Int,
+                         groupsZ: Int,
+                         bindings: BindingSet,
+                         pushConstants: UnsafeRawPointer?) throws {
+        _ = (pipeline, groupsX, groupsY, groupsZ, bindings, pushConstants)
+        throw AgentError.notImplemented
+    }
+}
+
+final class SceneGraphPushConstantTests: XCTestCase {
+    func testSceneGraphPushConstantsIncludeBaseColor() async throws {
+        try await MainActor.run {
+            let window = SDLWindow(config: .init(title: "PC", width: 128, height: 128))
+            let backend = try RecordingRenderBackend(window: window)
+            let mesh = try MeshFactory.makeLitCube(backend: backend, size: 1.0)
+            let baseColor: (Float, Float, Float, Float) = (0.25, 0.5, 0.75, 1.0)
+            let light: (Float, Float, Float) = (0.1, -0.2, 0.3)
+            let material = Material(
+                shader: ShaderID("basic_lit"),
+                params: MaterialParams(lightDirection: light, baseColor: baseColor)
+            )
+            let node = SceneNode(name: "Tinted", mesh: mesh, material: material)
+            let root = SceneNode(name: "Root")
+            root.addChild(node)
+            let scene = Scene(root: root, camera: nil, lightDirection: (0.3, -0.5, 0.8))
+
+            try SceneGraphRenderer.updateAndRender(scene: scene, backend: backend)
+
+            XCTAssertEqual(backend.drawCallCount, 1)
+            guard let push = backend.lastPushConstants else {
+                XCTFail("Expected push constants to be recorded")
+                return
+            }
+            XCTAssertEqual(push.count, 24)
+            let recordedLight = Array(push[16..<20])
+            XCTAssertEqual(recordedLight[0], light.0, accuracy: 1e-6)
+            XCTAssertEqual(recordedLight[1], light.1, accuracy: 1e-6)
+            XCTAssertEqual(recordedLight[2], light.2, accuracy: 1e-6)
+            let recordedBase = Array(push[20..<24])
+            XCTAssertEqual(recordedBase[0], baseColor.0, accuracy: 1e-6)
+            XCTAssertEqual(recordedBase[1], baseColor.1, accuracy: 1e-6)
+            XCTAssertEqual(recordedBase[2], baseColor.2, accuracy: 1e-6)
+            XCTAssertEqual(recordedBase[3], baseColor.3, accuracy: 1e-6)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend the Metal shaders to accept baseColor push constants and tint fragment output
- update MetalRenderBackend to copy the full 96-byte scene constants block, bind resources from BindingSet, and default base color/light when none are provided
- tint the Metal golden capture path and add a regression test that verifies SceneGraph push constants carry baseColor data

## Testing
- swift test (fails: JSONRouterTests.testRemovingExternalSpecFallsBackToEmbeddedVersion / SDLKitTests.testVersionReflectsExternalSpec expect older OpenAPI version)


------
https://chatgpt.com/codex/tasks/task_b_68dd3c2e4f148333a007a565aa2b07b0