### PR TITLE
Ensure decoded shader artifacts match source modification dates

### DIFF
--- a/Sources/SDLKit/Graphics/ShaderArtifactMaterializer.swift
+++ b/Sources/SDLKit/Graphics/ShaderArtifactMaterializer.swift
@@ -43,6 +43,13 @@ enum ShaderArtifactMaterializer {
         }
         try fm.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
         try decoded.write(to: url, options: .atomic)
+
+        if let base64Attributes = try? fm.attributesOfItem(atPath: base64URL.path),
+           let base64Date = base64Attributes[.modificationDate] as? Date {
+            try? fm.setAttributes([
+                .modificationDate: base64Date
+            ], ofItemAtPath: artifactPath)
+        }
         return url
     }
 


### PR DESCRIPTION
## Summary
- ensure shader artifacts recreated from base64 payloads inherit the original modification date so timestamp checks stay consistent

## Testing
- swift test --filter ShaderArtifactsTests/testCompiledShadersArePresentAndUpToDate


------
https://chatgpt.com/codex/tasks/task_b_68dd4e7284dc833399288b78427cda12