### PR TITLE
Plan Metal CI validation and backend readiness follow-ups

### DIFF
--- a/docs/BackendReadinessChecklist.md
+++ b/docs/BackendReadinessChecklist.md
@@ -29,10 +29,11 @@ Legend: ✅ — Verified in current builds, ⚠️ — Partial or pending follow
 ### Metal (macOS)
 
 1. Launch `SDLKitDemo` with the Metal backend in debug configuration.
-2. Verify window creation without API validation errors.
-3. Render the lit textured scene and adjust base color through debug UI; confirm tint propagates via push constants and textures remain sampled.
-4. Resize window between standard aspect ratios (16:9, 4:3) and ensure swapchain/depth resources recreate without flicker.
-5. Capture golden images for unlit and lit textured scenes; compare with stored baselines and archive updated hashes if deviations are expected.
+2. Export `SDLKIT_METAL_VALIDATION=1` and `SDLKIT_GOLDEN=1` to match CI validation coverage.
+3. Verify window creation without API validation errors.
+4. Render the lit textured scene and adjust base color through debug UI; confirm tint propagates via push constants and textures remain sampled.
+5. Resize window between standard aspect ratios (16:9, 4:3) and ensure swapchain/depth resources recreate without flicker.
+6. Capture golden images for unlit and lit textured scenes; compare with stored baselines and archive updated hashes if deviations are expected. Attach captured hashes/logs to the CI artifact bucket for review.
 
 ### Vulkan (Linux)
 
@@ -42,6 +43,13 @@ Legend: ✅ — Verified in current builds, ⚠️ — Partial or pending follow
 4. Force a window resize and validate swapchain recreation (new depth image, framebuffer rebuild).
 5. Export rendered frames for golden-image comparison and archive logs from validation layers. Ensure CI runs with `SDLKIT_VK_VALIDATION_CAPTURE=1` remain warning-free.
 
+### D3D12 (Windows)
+
+1. Launch `SDLKitDemo` on a Windows validation machine with the D3D12 backend and the debug layer enabled.
+2. Ensure the lit textured scene renders using the shared BindingSet resource path and that descriptor heaps do not overflow (monitor debug output for heap exhaustion warnings).
+3. Capture golden frames and compare hashes with the CI baselines produced by the Vulkan/Metal runs to confirm cross-backend parity.
+4. Record driver version, GPU, and any deviations; feed these into the cross-backend verification report.
+
 ---
 
 ## Known Limitations Blocking Beta
@@ -49,5 +57,17 @@ Legend: ✅ — Verified in current builds, ⚠️ — Partial or pending follow
 - **Automated Metal validation coverage**: Golden-image harness still runs manually; integrate Metal API validation into CI to catch regressions sooner.
 - **Cross-backend device verification**: Schedule a coordinated pass on physical hardware to confirm the updated BindingSet-driven textured scenes across Metal, Vulkan, and D3D12.
 - **Compute scheduling**: GPU compute interoperability is scheduled for the next milestone and is not considered part of the alpha readiness scope.
+
+---
+
+## Beta-Readiness Delta Tracking
+
+| Backend | Remaining Gaps | Owners | Target Date |
+| --- | --- | --- | --- |
+| Metal | ✅ CI integration pending: land `macos-metal-golden` job with validation toggles enforced.<br>⚠️ Document recovery procedure when golden hashes drift between debug/profile builds. | GraphicsAgent + Release Eng | 2024-05-24 |
+| Vulkan | ⚠️ Run extended resize/soak campaign on AMD + Mesa to validate swapchain robustness.<br>⚠️ Capture validation logs for cross-backend report. | GraphicsAgent (Linux) | 2024-05-28 |
+| D3D12 | ⚠️ Gather descriptor heap telemetry under prolonged golden runs.<br>⚠️ Confirm golden outputs match Metal/Vulkan captures after pipeline cache warm-up. | GraphicsAgent (Windows) | 2024-05-29 |
+
+> Update this table after each verification pass so the stabilization review has an authoritative delta list.
 
 Keep this checklist updated as tasks in the [Metal & Vulkan Alpha Stabilization Task Matrix](MetalVulkanAlphaTaskMatrix.md) progress.

--- a/docs/MetalVulkanAlphaTaskMatrix.md
+++ b/docs/MetalVulkanAlphaTaskMatrix.md
@@ -54,7 +54,16 @@ This matrix tracks the concrete work required to graduate SDLKit's Metal (macOS)
 
 ## Next Steps
 
-- ☐ Finish the Metal validation work by integrating the expanded golden-image harness into CI and enforcing API validation toggles for debug runs.
-- ☐ Schedule a cross-backend verification pass that replays the lit textured scene on physical devices to confirm the new resource-binding paths.
-- ☐ Draft the beta-readiness delta list (per backend) so remaining blockers after Metal validation are documented ahead of the stabilization review.
+- ☐▶ **Integrate Metal golden-image harness into CI**
+  - Add a `macos-metal-golden` lane to the GitHub Actions matrix that runs the lit and unlit golden scenes with `SDLKIT_METAL_VALIDATION=1` and `SDLKIT_GOLDEN=1`.
+  - Gate the job on debug/profile configurations so API validation stays enforced while still allowing opt-out for release builds.
+  - Publish captured hashes as build artifacts and fail the job when validation output contains warnings.
+- ☐ **Cross-backend verification pass**
+  - Coordinate device availability (Apple M2, AMD RDNA2 Linux, NVIDIA RTX Windows) and execute the lit textured scene on each backend with the refreshed BindingSet paths.
+  - Capture logs, validation outputs, and golden frames for the shared report that will feed into the readiness checklist.
+  - File regressions against backend owners within one business day of test completion.
+- ☐ **Draft beta-readiness deltas per backend**
+  - Use the readiness checklist template to enumerate blockers beyond Metal validation (e.g., Vulkan resize soak testing, D3D12 descriptor pool telemetry).
+  - Highlight tasks requiring cross-team support (tooling, QA) and attach tentative owners/dates.
+  - Circulate the draft before the stabilization review so the backlog can be triaged.
 


### PR DESCRIPTION
## Summary
- expand the alpha task matrix next steps with concrete actions for Metal CI validation, cross-backend verification, and beta delta drafting
- update the readiness checklist to mirror the validation toggles, add D3D12 manual coverage, and track backend-specific beta deltas

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68dd6a7eb58c83339aa21c6a0b8b0b17