### PR TITLE
Enforce explicit material constants for push-constant pipelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,12 +114,12 @@ public protocol RenderBackend {
 
     func makePipeline(_ desc: GraphicsPipelineDescriptor) throws -> PipelineHandle
     func draw(mesh: MeshHandle, pipeline: PipelineHandle,
-              bindings: BindingSet, pushConstants: UnsafeRawPointer?,
+              bindings: BindingSet,
               transform: float4x4) throws
 
     func makeComputePipeline(_ desc: ComputePipelineDescriptor) throws -> ComputePipelineHandle
     func dispatchCompute(_ p: ComputePipelineHandle, groupsX: Int, groupsY: Int, groupsZ: Int,
-                         bindings: BindingSet, pushConstants: UnsafeRawPointer?) throws
+                         bindings: BindingSet) throws
 }
 ```
 
@@ -137,7 +137,7 @@ public protocol ShaderLibrary {
 public protocol ComputeScheduler {
     func makeComputePipeline(_ d: ComputePipelineDescriptor) throws -> ComputePipelineHandle
     func dispatch(_ groups: (Int, Int, Int), pipeline: ComputePipelineHandle,
-                  bindings: BindingSet, pushConstants: UnsafeRawPointer?) throws
+                  bindings: BindingSet) throws
     func readback(buffer: BufferHandle, into dst: UnsafeMutableRawPointer, length: Int) throws
 }
 ```

--- a/ComputeAgent.md
+++ b/ComputeAgent.md
@@ -37,8 +37,7 @@ public protocol ComputeScheduler {
     func makeComputePipeline(_ desc: ComputePipelineDescriptor) throws -> ComputePipelineHandle
     func dispatch(_ d: ComputeDispatch,
                   pipeline: ComputePipelineHandle,
-                  bindings: BindingSet,
-                  pushConstants: UnsafeRawPointer?) throws
+                  bindings: BindingSet) throws
     func readback(buffer: BufferHandle, into: UnsafeMutableRawPointer, length: Int) throws
 }
 ```

--- a/GraphicsAgent.md
+++ b/GraphicsAgent.md
@@ -53,15 +53,13 @@ public protocol RenderBackend {
     func draw(mesh: MeshHandle,
               pipeline: PipelineHandle,
               bindings: BindingSet,
-              pushConstants: UnsafeRawPointer?,
               transform: float4x4) throws
 
     // Pipelines (compute)
     func makeComputePipeline(_ desc: ComputePipelineDescriptor) throws -> ComputePipelineHandle
     func dispatchCompute(_ pipeline: ComputePipelineHandle,
                          groupsX: Int, groupsY: Int, groupsZ: Int,
-                         bindings: BindingSet,
-                         pushConstants: UnsafeRawPointer?) throws
+                         bindings: BindingSet) throws
 }
 ```
 

--- a/Package.swift
+++ b/Package.swift
@@ -207,6 +207,14 @@ let package = Package(
         )
 
         targets.append(
+            .testTarget(
+                name: "SDLKitGraphicsTests",
+                dependencies: ["SDLKit"],
+                path: "Tests/SDLKitGraphicsTests"
+            )
+        )
+
+        targets.append(
             .executableTarget(
                 name: "SDLKitDemo",
                 dependencies: {

--- a/SceneGraphAgent.md
+++ b/SceneGraphAgent.md
@@ -70,7 +70,6 @@ func updateAndRender(scene: Scene, backend: RenderBackend) {
         try? backend.draw(mesh: m.vertexBuffer.asMeshHandle(index: m.indexBuffer, count: m.indexCount),
                           pipeline: m.material.pipeline,
                           bindings: m.material.bindings,
-                          pushConstants: nil,
                           transform: node.worldTransform)
     }
     try? backend.endFrame()

--- a/Sources/SDLKit/Graphics/BackendFactory.swift
+++ b/Sources/SDLKit/Graphics/BackendFactory.swift
@@ -190,7 +190,6 @@ final class StubRenderBackendCore {
     func draw(mesh: MeshHandle,
               pipeline: PipelineHandle,
               bindings: BindingSet,
-              pushConstants: UnsafeRawPointer?,
               transform: float4x4) throws {
         guard frameActive else {
             throw AgentError.internalError("draw called outside beginFrame/endFrame")
@@ -206,7 +205,6 @@ final class StubRenderBackendCore {
             "draw mesh=\(mesh.rawValue) pipeline=\(pipeline.rawValue) vertexBuffer=\(meshResource.vertexBuffer.rawValue) vertexCount=\(meshResource.vertexCount) indexBuffer=\(meshResource.indexBuffer?.rawValue ?? 0) indexCount=\(meshResource.indexCount)"
         )
         _ = bindings
-        _ = pushConstants
         _ = transform
     }
 
@@ -219,14 +217,12 @@ final class StubRenderBackendCore {
 
     func dispatchCompute(_ pipeline: ComputePipelineHandle,
                          groupsX: Int, groupsY: Int, groupsZ: Int,
-                         bindings: BindingSet,
-                         pushConstants: UnsafeRawPointer?) throws {
+                         bindings: BindingSet) throws {
         guard computePipelines[pipeline] != nil else {
             throw AgentError.internalError("Unknown compute pipeline")
         }
         SDLLogger.debug("SDLKit.Graphics", "dispatchCompute pipeline=\(pipeline.rawValue) groups=(\(groupsX),\(groupsY),\(groupsZ))")
         _ = bindings
-        _ = pushConstants
     }
 }
 
@@ -250,9 +246,9 @@ public class StubRenderBackend: RenderBackend {
     public func createTexture(descriptor: TextureDescriptor, initialData: TextureInitialData?) throws -> TextureHandle { core.createTexture(descriptor: descriptor, initialData: initialData) }
     public func destroy(_ handle: ResourceHandle) { core.destroy(handle) }
     public func makePipeline(_ desc: GraphicsPipelineDescriptor) throws -> PipelineHandle { core.makePipeline(desc) }
-    public func draw(mesh: MeshHandle, pipeline: PipelineHandle, bindings: BindingSet, pushConstants: UnsafeRawPointer?, transform: float4x4) throws { try core.draw(mesh: mesh, pipeline: pipeline, bindings: bindings, pushConstants: pushConstants, transform: transform) }
+    public func draw(mesh: MeshHandle, pipeline: PipelineHandle, bindings: BindingSet, transform: float4x4) throws { try core.draw(mesh: mesh, pipeline: pipeline, bindings: bindings, transform: transform) }
     public func makeComputePipeline(_ desc: ComputePipelineDescriptor) throws -> ComputePipelineHandle { core.makeComputePipeline(desc) }
-    public func dispatchCompute(_ pipeline: ComputePipelineHandle, groupsX: Int, groupsY: Int, groupsZ: Int, bindings: BindingSet, pushConstants: UnsafeRawPointer?) throws { try core.dispatchCompute(pipeline, groupsX: groupsX, groupsY: groupsY, groupsZ: groupsZ, bindings: bindings, pushConstants: pushConstants) }
+    public func dispatchCompute(_ pipeline: ComputePipelineHandle, groupsX: Int, groupsY: Int, groupsZ: Int, bindings: BindingSet) throws { try core.dispatchCompute(pipeline, groupsX: groupsX, groupsY: groupsY, groupsZ: groupsZ, bindings: bindings) }
 
     public func registerMesh(vertexBuffer: BufferHandle,
                              vertexCount: Int,

--- a/Sources/SDLKit/SceneGraph/SceneGraph.swift
+++ b/Sources/SDLKit/SceneGraph/SceneGraph.swift
@@ -206,15 +206,14 @@ public enum SceneGraphRenderer {
             var data = mvp.toFloatArray()
             data.append(contentsOf: [matLight.0, matLight.1, matLight.2, 0.0])
             data.append(contentsOf: [base.0, base.1, base.2, base.3])
-            try data.withUnsafeBytes { bytes in
-                try backend.draw(
-                    mesh: meshHandle,
-                    pipeline: pipeline,
-                    bindings: bindings,
-                    pushConstants: bytes.baseAddress,
-                    transform: mvp
-                )
-            }
+            let constantsData = data.withUnsafeBytes { buffer in Data(buffer) }
+            bindings.materialConstants = BindingSet.MaterialConstants(data: constantsData)
+            try backend.draw(
+                mesh: meshHandle,
+                pipeline: pipeline,
+                bindings: bindings,
+                transform: mvp
+            )
         }
         for child in node.children { try renderNode(child, backend: backend, colorFormat: colorFormat, depthFormat: depthFormat, vp: vp, lightDir: lightDir) }
     }

--- a/Sources/SDLKit/SceneGraph/SceneGraphComputeInterop.swift
+++ b/Sources/SDLKit/SceneGraph/SceneGraphComputeInterop.swift
@@ -84,8 +84,7 @@ public enum SceneGraphComputeInterop {
             groupsX: resources.vertexCount,
             groupsY: 1,
             groupsZ: 1,
-            bindings: bindings,
-            pushConstants: nil
+            bindings: bindings
         )
         try applyCPUFallbackIfNeeded(backend: backend, resources: resources)
     }

--- a/Sources/SDLKitDemo/main.swift
+++ b/Sources/SDLKitDemo/main.swift
@@ -189,7 +189,6 @@ struct DemoApp {
                 mesh: mesh,
                 pipeline: pipeline,
                 bindings: bindings,
-                pushConstants: nil,
                 transform: float4x4.identity
             )
             try backend.endFrame()

--- a/Tests/SDLKitGraphicsTests/PushConstantValidationTests.swift
+++ b/Tests/SDLKitGraphicsTests/PushConstantValidationTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+import XCTest
+@testable import SDLKit
+
+@MainActor
+private final class EnforcingBackend: RenderBackend {
+    private var frameActive = false
+    private let window: SDLWindow
+    private let computeOverride: Int?
+    private var pipelineRequirements: [PipelineHandle: Int] = [:]
+    private var computeRequirements: [ComputePipelineHandle: Int] = [:]
+
+    private init(baseWindow: SDLWindow, override: Int?) {
+        self.window = baseWindow
+        self.computeOverride = override
+    }
+
+    convenience init(window: SDLWindow, computeOverride: Int? = nil) throws {
+        self.init(baseWindow: window, override: computeOverride)
+    }
+
+    required convenience init(window: SDLWindow) throws {
+        try self.init(window: window, computeOverride: nil)
+    }
+
+    func beginFrame() throws {
+        guard !frameActive else { throw AgentError.internalError("beginFrame called twice") }
+        frameActive = true
+    }
+
+    func endFrame() throws {
+        guard frameActive else { throw AgentError.internalError("endFrame without beginFrame") }
+        frameActive = false
+    }
+
+    func resize(width: Int, height: Int) throws {
+        _ = (width, height)
+    }
+
+    func waitGPU() throws {}
+
+    func createBuffer(bytes: UnsafeRawPointer?, length: Int, usage: BufferUsage) throws -> BufferHandle {
+        _ = (bytes, length, usage)
+        return BufferHandle()
+    }
+
+    func createTexture(descriptor: TextureDescriptor, initialData: TextureInitialData?) throws -> TextureHandle {
+        _ = (descriptor, initialData)
+        return TextureHandle()
+    }
+
+    func destroy(_ handle: ResourceHandle) {
+        _ = handle
+    }
+
+    func registerMesh(vertexBuffer: BufferHandle,
+                      vertexCount: Int,
+                      indexBuffer: BufferHandle?,
+                      indexCount: Int,
+                      indexFormat: IndexFormat) throws -> MeshHandle {
+        _ = (vertexBuffer, vertexCount, indexBuffer, indexCount, indexFormat)
+        return MeshHandle()
+    }
+
+    func makePipeline(_ desc: GraphicsPipelineDescriptor) throws -> PipelineHandle {
+        let handle = PipelineHandle()
+        let module = try ShaderLibrary.shared.module(for: desc.shader)
+        pipelineRequirements[handle] = module.pushConstantSize
+        return handle
+    }
+
+    func draw(mesh: MeshHandle,
+              pipeline: PipelineHandle,
+              bindings: BindingSet,
+              transform: float4x4) throws {
+        guard frameActive else { throw AgentError.internalError("draw outside beginFrame/endFrame") }
+        _ = (mesh, transform)
+        let expected = pipelineRequirements[pipeline] ?? 0
+        if expected > 0 {
+            guard let payload = bindings.materialConstants else {
+                let message = "Shader requires \(expected) bytes of material constants but none were provided."
+                SDLLogger.error("SDLKit.Graphics.Tests", message)
+                throw AgentError.invalidArgument(message)
+            }
+            guard payload.byteCount == expected else {
+                let message = "Shader requires \(expected) bytes of material constants but received \(payload.byteCount)."
+                SDLLogger.error("SDLKit.Graphics.Tests", message)
+                throw AgentError.invalidArgument(message)
+            }
+        }
+    }
+
+    func makeComputePipeline(_ desc: ComputePipelineDescriptor) throws -> ComputePipelineHandle {
+        let handle = ComputePipelineHandle()
+        let expected = computeOverride ?? (try? ShaderLibrary.shared.computeModule(for: desc.shader).pushConstantSize) ?? 0
+        computeRequirements[handle] = expected
+        return handle
+    }
+
+    func dispatchCompute(_ pipeline: ComputePipelineHandle,
+                         groupsX: Int,
+                         groupsY: Int,
+                         groupsZ: Int,
+                         bindings: BindingSet) throws {
+        guard frameActive else { throw AgentError.internalError("dispatchCompute outside beginFrame/endFrame") }
+        _ = (pipeline, groupsX, groupsY, groupsZ)
+        let expected = computeRequirements[pipeline] ?? 0
+        if expected > 0 {
+            guard let payload = bindings.materialConstants else {
+                let message = "Compute shader requires \(expected) bytes of push constants but none were provided."
+                SDLLogger.error("SDLKit.Graphics.Tests", message)
+                throw AgentError.invalidArgument(message)
+            }
+            guard payload.byteCount == expected else {
+                let message = "Compute shader requires \(expected) bytes of push constants but received \(payload.byteCount)."
+                SDLLogger.error("SDLKit.Graphics.Tests", message)
+                throw AgentError.invalidArgument(message)
+            }
+        }
+    }
+}
+
+final class PushConstantValidationTests: XCTestCase {
+    func testDrawWithoutMaterialConstantsThrows() async throws {
+        try await MainActor.run {
+            let window = SDLWindow(config: .init(title: "DrawValidation", width: 64, height: 64))
+            let backend = try EnforcingBackend(window: window)
+            let shader = ShaderID("basic_lit")
+            let module = try ShaderLibrary.shared.module(for: shader)
+            let descriptor = GraphicsPipelineDescriptor(
+                label: "test",
+                shader: shader,
+                vertexLayout: module.vertexLayout,
+                colorFormats: [.bgra8Unorm]
+            )
+            let pipeline = try backend.makePipeline(descriptor)
+            let mesh = try backend.registerMesh(vertexBuffer: BufferHandle(), vertexCount: 3, indexBuffer: nil, indexCount: 0, indexFormat: .uint16)
+
+            try backend.beginFrame()
+            defer { try? backend.endFrame() }
+
+            var bindings = BindingSet()
+            XCTAssertThrowsError(try backend.draw(mesh: mesh, pipeline: pipeline, bindings: bindings, transform: .identity)) { error in
+                guard case AgentError.invalidArgument = error else {
+                    return XCTFail("Expected invalidArgument error")
+                }
+            }
+
+            var data = Data(count: module.pushConstantSize)
+            data.withUnsafeMutableBytes { buffer in
+                if let base = buffer.baseAddress {
+                    memset(base, 0, buffer.count)
+                }
+            }
+            bindings.materialConstants = BindingSet.MaterialConstants(data: data)
+            XCTAssertNoThrow(try backend.draw(mesh: mesh, pipeline: pipeline, bindings: bindings, transform: .identity))
+        }
+    }
+
+    func testDispatchWithoutConstantsThrows() async throws {
+        try await MainActor.run {
+            let window = SDLWindow(config: .init(title: "DispatchValidation", width: 64, height: 64))
+            let backend = try EnforcingBackend(window: window, computeOverride: 16)
+            let descriptor = ComputePipelineDescriptor(label: "computeTest", shader: ShaderID("vector_add"))
+            let pipeline = try backend.makeComputePipeline(descriptor)
+
+            try backend.beginFrame()
+            defer { try? backend.endFrame() }
+
+            let bindings = BindingSet()
+            XCTAssertThrowsError(try backend.dispatchCompute(pipeline, groupsX: 1, groupsY: 1, groupsZ: 1, bindings: bindings)) { error in
+                guard case AgentError.invalidArgument = error else {
+                    return XCTFail("Expected invalidArgument error")
+                }
+            }
+
+            var bindingsWithData = BindingSet()
+            bindingsWithData.materialConstants = BindingSet.MaterialConstants(data: Data(repeating: 0, count: 16))
+            XCTAssertNoThrow(try backend.dispatchCompute(pipeline, groupsX: 1, groupsY: 1, groupsZ: 1, bindings: bindingsWithData))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a BindingSet.MaterialConstants wrapper and require RenderBackend draw/dispatch calls to provide explicit payloads
- harden the Metal, D3D12, and Vulkan backends to log and throw when push-constant data is missing or mis-sized instead of injecting defaults
- update scene graph usage and docs for the new API and add SDLKitGraphicsTests covering missing material/compute constants

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68dd709568bc8333abf4d7c0c4f73a32