### PR TITLE
Add explicit sampler handling to rendering backends

### DIFF
--- a/ComputeAgent.md
+++ b/ComputeAgent.md
@@ -42,6 +42,11 @@ public protocol ComputeScheduler {
 }
 ```
 
+### Samplers in Compute Workflows
+- Compute shaders that sample textures must request sampler handles from the graphics backend (`RenderBackend.createSampler`).
+- Bind sampler handles explicitly via `BindingSet.setSampler(_, at:)` to ensure filtering and addressing state is consistent across platforms.
+- `BindingSet` validation rejects mismatched resource types at dispatch time, surfacing incorrect bindings early in development.
+
 **Inputs**
 - Compiled compute shader binaries from **ShaderAgent**.
 - Resource handles (buffers/textures) from **GraphicsAgent**.

--- a/GraphicsAgent.md
+++ b/GraphicsAgent.md
@@ -46,6 +46,7 @@ public protocol RenderBackend {
     // Resources
     func createBuffer(bytes: UnsafeRawPointer?, length: Int, usage: BufferUsage) throws -> BufferHandle
     func createTexture(descriptor: TextureDescriptor, initialData: TextureInitialData?) throws -> TextureHandle
+    func createSampler(descriptor: SamplerDescriptor) throws -> SamplerHandle
     func destroy(_ handle: ResourceHandle)
 
     // Pipelines (graphics)

--- a/SceneGraphAgent.md
+++ b/SceneGraphAgent.md
@@ -76,6 +76,17 @@ func updateAndRender(scene: Scene, backend: RenderBackend) {
 }
 ```
 
+### Sampler Bindings
+
+- Materials that sample textures should request explicit sampler state objects from `RenderBackend.createSampler` during material setup.
+- Populate both the texture and sampler slots when filling a `BindingSet`:
+  ```swift
+  var bindings = BindingSet()
+  bindings.setTexture(albedoTextureHandle, at: 10)
+  bindings.setSampler(linearWrapSampler, at: 10) // same slot as texture sampler declared in shader
+  ```
+- This explicit pairing ensures shaders receive the correct filtering and addressing modes across Metal, D3D12, and Vulkan.
+
 ---
 
 ## Inputs

--- a/Sources/SDLKit/Graphics/BackendFactory.swift
+++ b/Sources/SDLKit/Graphics/BackendFactory.swift
@@ -59,6 +59,7 @@ final class StubRenderBackendCore {
     private(set) var currentSize: (width: Int, height: Int)
     private var buffers: [BufferHandle: BufferResource] = [:]
     private var textures: [TextureHandle: TextureResource] = [:]
+    private var samplers: [SamplerHandle: SamplerDescriptor] = [:]
     private var pipelines: [PipelineHandle: PipelineResource] = [:]
     private var computePipelines: [ComputePipelineHandle: ComputePipelineResource] = [:]
     private var meshes: [MeshHandle: MeshResource] = [:]
@@ -161,12 +162,21 @@ final class StubRenderBackendCore {
         return handle
     }
 
+    func createSampler(descriptor: SamplerDescriptor) -> SamplerHandle {
+        let handle = SamplerHandle()
+        samplers[handle] = descriptor
+        SDLLogger.debug("SDLKit.Graphics", "createSampler id=\(handle.rawValue) label=\(descriptor.label ?? "<nil>")")
+        return handle
+    }
+
     func destroy(_ handle: ResourceHandle) {
         switch handle {
         case .buffer(let h):
             buffers.removeValue(forKey: h)
         case .texture(let h):
             textures.removeValue(forKey: h)
+        case .sampler(let h):
+            samplers.removeValue(forKey: h)
         case .pipeline(let h):
             pipelines.removeValue(forKey: h)
         case .computePipeline(let h):
@@ -244,6 +254,7 @@ public class StubRenderBackend: RenderBackend {
     public func waitGPU() throws { core.waitGPU() }
     public func createBuffer(bytes: UnsafeRawPointer?, length: Int, usage: BufferUsage) throws -> BufferHandle { core.createBuffer(bytes: bytes, length: length, usage: usage) }
     public func createTexture(descriptor: TextureDescriptor, initialData: TextureInitialData?) throws -> TextureHandle { core.createTexture(descriptor: descriptor, initialData: initialData) }
+    public func createSampler(descriptor: SamplerDescriptor) throws -> SamplerHandle { core.createSampler(descriptor: descriptor) }
     public func destroy(_ handle: ResourceHandle) { core.destroy(handle) }
     public func makePipeline(_ desc: GraphicsPipelineDescriptor) throws -> PipelineHandle { core.makePipeline(desc) }
     public func draw(mesh: MeshHandle, pipeline: PipelineHandle, bindings: BindingSet, transform: float4x4) throws { try core.draw(mesh: mesh, pipeline: pipeline, bindings: bindings, transform: transform) }

--- a/Sources/SDLKit/SceneGraph/SceneGraph.swift
+++ b/Sources/SDLKit/SceneGraph/SceneGraph.swift
@@ -195,7 +195,7 @@ public enum SceneGraphRenderer {
             node.mesh = mesh
             var bindings = BindingSet()
             if let textureHandle = material.params.texture {
-                bindings.setValue(textureHandle, for: 10) // fragment texture slot 0
+                bindings.setTexture(textureHandle, at: 10) // fragment texture slot 0
             }
             let mvp = node.worldTransform * vp
             // Determine light direction preference: material overrides scene

--- a/Sources/SDLKit/SceneGraph/SceneGraphComputeInterop.swift
+++ b/Sources/SDLKit/SceneGraph/SceneGraphComputeInterop.swift
@@ -76,9 +76,9 @@ public enum SceneGraphComputeInterop {
 
     public static func dispatchCompute(backend: RenderBackend, resources: Resources) throws {
         var bindings = BindingSet()
-        bindings.setValue(resources.stateBuffer, for: 0)
-        bindings.setValue(resources.configBuffer, for: 1)
-        bindings.setValue(resources.vertexBuffer, for: 2)
+        bindings.setBuffer(resources.stateBuffer, at: 0)
+        bindings.setBuffer(resources.configBuffer, at: 1)
+        bindings.setBuffer(resources.vertexBuffer, at: 2)
         try backend.dispatchCompute(
             resources.computePipeline,
             groupsX: resources.vertexCount,

--- a/Tests/SDLKitGraphicsTests/PushConstantValidationTests.swift
+++ b/Tests/SDLKitGraphicsTests/PushConstantValidationTests.swift
@@ -49,6 +49,11 @@ private final class EnforcingBackend: RenderBackend {
         return TextureHandle()
     }
 
+    func createSampler(descriptor: SamplerDescriptor) throws -> SamplerHandle {
+        _ = descriptor
+        return SamplerHandle()
+    }
+
     func destroy(_ handle: ResourceHandle) {
         _ = handle
     }

--- a/Tests/SDLKitTests/SceneGraphPushConstantTests.swift
+++ b/Tests/SDLKitTests/SceneGraphPushConstantTests.swift
@@ -57,10 +57,16 @@ private final class RecordingRenderBackend: RenderBackend {
         return handle
     }
 
+    func createSampler(descriptor: SamplerDescriptor) throws -> SamplerHandle {
+        _ = descriptor
+        return SamplerHandle()
+    }
+
     func destroy(_ handle: ResourceHandle) {
         switch handle {
         case .buffer(let h): buffers.removeValue(forKey: h)
         case .texture(let h): textures.removeValue(forKey: h)
+        case .sampler: break
         case .pipeline(let h): pipelines.removeValue(forKey: h)
         case .computePipeline: break
         case .mesh(let h): meshes.removeValue(forKey: h)
@@ -198,7 +204,7 @@ final class SceneGraphPushConstantTests: XCTestCase {
                 XCTFail("Expected bindings to be recorded")
                 return
             }
-            let boundTexture: TextureHandle? = bindings.value(for: 10, as: TextureHandle.self)
+            let boundTexture = bindings.texture(at: 10)
             XCTAssertEqual(boundTexture, textureHandle)
         }
     }

--- a/sdlkit.render.v1.yaml
+++ b/sdlkit.render.v1.yaml
@@ -704,6 +704,13 @@ components:
           type: string
           pattern: '^0x[0-9A-Fa-f]{1,16}$'
       required: [id]
+    SamplerHandle:
+      type: object
+      properties:
+        id:
+          type: string
+          pattern: '^0x[0-9A-Fa-f]{1,16}$'
+      required: [id]
     PipelineHandle:
       type: object
       properties:
@@ -800,6 +807,7 @@ components:
           oneOf:
             - $ref: '#/components/schemas/BufferHandle'
             - $ref: '#/components/schemas/TextureHandle'
+            - $ref: '#/components/schemas/SamplerHandle'
         array_index: { type: integer, minimum: 0, default: 0 }
       required: [slot, kind, handle]
     BindingSet:
@@ -810,13 +818,13 @@ components:
           items: { $ref: '#/components/schemas/BindingResource' }
         samplers:
           type: array
-          description: Optional sampler descriptors referenced by binding slots.
+          description: Sampler handles associated with specific binding slots.
           items:
             type: object
             properties:
               slot: { type: integer, minimum: 0 }
-              descriptor: { type: object }
-            required: [slot, descriptor]
+              handle: { $ref: '#/components/schemas/SamplerHandle' }
+            required: [slot, handle]
       required: [resources]
     GraphicsPipelineDescriptor:
       type: object


### PR DESCRIPTION
## Summary
- add SamplerHandle and creation APIs to the shared RenderBackend surface
- validate binding sets and hook up sampler creation/destruction across Metal, D3D12, and Vulkan
- update documentation and OpenAPI schema to document explicit sampler bindings for scene graph and compute agents

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68ddeda935c483339d3b14d0eac69899