### PR TITLE
Handle Metal compute texture barriers

### DIFF
--- a/Tests/SDLKitGraphicsTests/MetalComputeTextureBarrierTests.swift
+++ b/Tests/SDLKitGraphicsTests/MetalComputeTextureBarrierTests.swift
@@ -1,0 +1,31 @@
+#if canImport(Metal)
+import XCTest
+@testable import SDLKit
+
+final class MetalComputeTextureBarrierTests: XCTestCase {
+    func testComputeWriteThenSampleRequiresBarrier() {
+        var tracker = MetalComputeTextureAccessTracker()
+        let handle = TextureHandle()
+        XCTAssertNil(tracker.register(handle: handle, requirement: .writable, usage: .shaderWrite))
+        XCTAssertNil(tracker.register(handle: handle, requirement: .readable, usage: .shaderWrite))
+        XCTAssertTrue(tracker.handlesNeedingBarrier.contains(handle))
+        XCTAssertNil(tracker.failureMessage(for: handle))
+    }
+
+    func testUnsupportedWriteUsageProducesFailureMessage() {
+        var tracker = MetalComputeTextureAccessTracker()
+        let handle = TextureHandle()
+        let message = tracker.register(handle: handle, requirement: .writable, usage: .renderTarget)
+        XCTAssertNotNil(message)
+        XCTAssertEqual(tracker.failureMessage(for: handle), message)
+        XCTAssertTrue(tracker.handlesNeedingBarrier.isEmpty)
+    }
+
+    func testRenderTargetReadableIsAccepted() {
+        var tracker = MetalComputeTextureAccessTracker()
+        let handle = TextureHandle()
+        XCTAssertNil(tracker.register(handle: handle, requirement: .readable, usage: .renderTarget))
+        XCTAssertTrue(tracker.handlesNeedingBarrier.contains(handle))
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- track Metal compute textures to emit memory barriers or blit-based transitions after compute dispatches
- log descriptive errors when textures lack the usage flags required for synchronization
- add Metal-specific unit tests that exercise the compute texture barrier tracker

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68de1dd186308333a4422f8106ea73be