### PR TITLE
Handle D3D12 device loss and add recovery test

### DIFF
--- a/Sources/SDLKit/Graphics/BackendFactory.swift
+++ b/Sources/SDLKit/Graphics/BackendFactory.swift
@@ -380,6 +380,7 @@ final class StubRenderBackendCore {
 @MainActor
 public class StubRenderBackend: RenderBackend {
     fileprivate let core: StubRenderBackendCore
+    public var deviceEventHandler: RenderBackendDeviceEventHandler?
 
     fileprivate init(kind: StubRenderBackendCore.Kind, window: SDLWindow) throws {
         self.core = try StubRenderBackendCore(kind: kind, window: window)

--- a/Sources/SDLKit/Graphics/Metal/MetalRenderBackend.swift
+++ b/Sources/SDLKit/Graphics/Metal/MetalRenderBackend.swift
@@ -79,6 +79,7 @@ public final class MetalRenderBackend: RenderBackend, GoldenImageCapturable {
     private var lastCaptureHash: String?
 
     private let shaderLibrary: ShaderLibrary
+    public var deviceEventHandler: RenderBackendDeviceEventHandler?
     private var metalLibraries: [ShaderID: MTLLibrary] = [:]
     private var drawableSize: CGSize
     private var depthPixelFormat: MTLPixelFormat?

--- a/Sources/SDLKit/Graphics/RenderBackend.swift
+++ b/Sources/SDLKit/Graphics/RenderBackend.swift
@@ -54,6 +54,14 @@ public struct ComputePipelineHandle: Hashable, Codable, Sendable {
     public init(rawValue: UInt64) { self.rawValue = rawValue }
 }
 
+public enum RenderBackendDeviceEvent: Sendable {
+    case willReset(reason: String)
+    case didReset
+    case resetFailed(reason: String)
+}
+
+public typealias RenderBackendDeviceEventHandler = @Sendable (RenderBackendDeviceEvent) -> Void
+
 public struct MeshHandle: Hashable, Codable, Sendable {
     public let rawValue: UInt64
     public init() { self.init(rawValue: UInt64.random(in: UInt64.min...UInt64.max)) }
@@ -341,6 +349,8 @@ public protocol RenderBackend {
     func endFrame() throws
     func resize(width: Int, height: Int) throws
     func waitGPU() throws
+
+    var deviceEventHandler: RenderBackendDeviceEventHandler? { get set }
 
     func createBuffer(bytes: UnsafeRawPointer?, length: Int, usage: BufferUsage) throws -> BufferHandle
     func createTexture(descriptor: TextureDescriptor, initialData: TextureInitialData?) throws -> TextureHandle

--- a/Sources/SDLKit/Graphics/Vulkan/VulkanRenderBackend.swift
+++ b/Sources/SDLKit/Graphics/Vulkan/VulkanRenderBackend.swift
@@ -23,6 +23,7 @@ public final class VulkanRenderBackend: RenderBackend, GoldenImageCapturable {
     private let window: SDLWindow
     private let surface: RenderSurface
     private var core: StubRenderBackendCore
+    public var deviceEventHandler: RenderBackendDeviceEventHandler?
 
     // Vulkan handles
     private var vkInstance = VulkanMinimalInstance()

--- a/Sources/SDLKit/Support/Errors.swift
+++ b/Sources/SDLKit/Support/Errors.swift
@@ -4,5 +4,6 @@ public enum AgentError: Error, Equatable {
     case notImplemented
     case invalidArgument(String)
     case internalError(String)
+    case deviceLost(String)
 }
 

--- a/Tests/SDLKitGraphicsTests/D3D12DeviceLossRecoveryTests.swift
+++ b/Tests/SDLKitGraphicsTests/D3D12DeviceLossRecoveryTests.swift
@@ -1,0 +1,90 @@
+#if os(Windows)
+import XCTest
+import Foundation
+import Direct3D12
+@testable import SDLKit
+
+@MainActor
+final class D3D12DeviceLossRecoveryTests: XCTestCase {
+    func testDeviceLossRecoveryRestoresResources() async throws {
+        try await MainActor.run {
+            let window = SDLWindow(config: .init(title: "DeviceLoss", width: 128, height: 128))
+            let backend = try D3D12RenderBackend(window: window)
+
+            var events: [RenderBackendDeviceEvent] = []
+            backend.deviceEventHandler = { event in
+                events.append(event)
+            }
+
+            let vertexModule = try ShaderLibrary.shared.module(for: ShaderID("unlit_triangle"))
+            let vertexStride = vertexModule.vertexLayout.stride
+            let vertexCount = 3
+            var vertexData = Data(count: vertexStride * vertexCount)
+            vertexData.withUnsafeMutableBytes { bytes in
+                guard let base = bytes.baseAddress?.assumingMemoryBound(to: Float.self) else { return }
+                // position + color
+                let values: [Float] = [
+                    -0.5, -0.5, 0.0, 1.0, 0.0, 0.0,
+                     0.0,  0.5, 0.0, 0.0, 1.0, 0.0,
+                     0.5, -0.5, 0.0, 0.0, 0.0, 1.0
+                ]
+                for (index, value) in values.enumerated() {
+                    base[index] = value
+                }
+            }
+            let vertexBuffer = try backend.createBuffer(bytes: vertexData.withUnsafeBytes { $0.baseAddress },
+                                                         length: vertexData.count,
+                                                         usage: .vertex)
+            let meshHandle = try backend.registerMesh(vertexBuffer: vertexBuffer,
+                                                       vertexCount: vertexCount,
+                                                       indexBuffer: nil,
+                                                       indexCount: 0,
+                                                       indexFormat: .uint16)
+
+            let textureBytes = Data(repeating: 0x7F, count: 64 * 64 * 4)
+            let textureDesc = TextureDescriptor(width: 64,
+                                                height: 64,
+                                                mipLevels: 1,
+                                                format: .rgba8Unorm,
+                                                usage: .shaderRead)
+            let texture = try backend.createTexture(descriptor: textureDesc,
+                                                    initialData: TextureInitialData(mipLevelData: [textureBytes]))
+            let sampler = try backend.createSampler(descriptor: SamplerDescriptor(label: "Linear"))
+
+            let pipelineDesc = GraphicsPipelineDescriptor(label: "DeviceLossPipeline",
+                                                          shader: vertexModule.id,
+                                                          vertexLayout: vertexModule.vertexLayout,
+                                                          colorFormats: [.bgra8Unorm],
+                                                          depthFormat: .depth32Float)
+            _ = try backend.makePipeline(pipelineDesc)
+
+            try backend.beginFrame()
+            backend.debugSimulateDeviceRemoval()
+            XCTAssertThrowsError(try backend.endFrame()) { error in
+                guard case AgentError.deviceLost = error else {
+                    XCTFail("Expected AgentError.deviceLost, received \(error)")
+                    return
+                }
+            }
+
+            XCTAssertTrue(events.contains { if case .willReset = $0 { return true } else { return false } })
+            XCTAssertTrue(events.contains { if case .didReset = $0 { return true } else { return false } })
+            XCTAssertNotNil(backend.debugTextureState(for: texture))
+#if DEBUG
+            XCTAssertNotNil(backend.debugSamplerDescriptor(for: sampler))
+#endif
+
+            try backend.beginFrame()
+            try backend.endFrame()
+
+            _ = try backend.registerMesh(vertexBuffer: vertexBuffer,
+                                         vertexCount: vertexCount,
+                                         indexBuffer: nil,
+                                         indexCount: 0,
+                                         indexFormat: .uint16)
+            _ = try backend.makePipeline(pipelineDesc)
+            _ = meshHandle
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add device-loss event signaling to render backends and SceneGraphRenderer
- rebuild D3D12 resources when the device is removed and expose a debug hook for tests
- cover recovery with a Windows-only stress test that simulates device removal

## Testing
- Not run (Windows-specific coverage)

------
https://chatgpt.com/codex/tasks/task_b_68de269d80b483338390da62ddbdaa26