### PR TITLE
Fix device loss JSON case and update mock backends

### DIFF
--- a/Sources/SDLKit/Agent/JSONTools.swift
+++ b/Sources/SDLKit/Agent/JSONTools.swift
@@ -699,6 +699,7 @@ public struct SDLKitJSONAgent {
         case .notImplemented: return errorJSON(code: "not_implemented", details: nil)
         case .invalidArgument(let msg): return errorJSON(code: "invalid_argument", details: msg)
         case .internalError(let msg): return errorJSON(code: "internal_error", details: msg)
+        case .deviceLost(let details): return errorJSON(code: "device_lost", details: details)
         }
     }
 }

--- a/Sources/SDLKit/SceneGraph/SceneGraph.swift
+++ b/Sources/SDLKit/SceneGraph/SceneGraph.swift
@@ -182,11 +182,14 @@ public enum SceneGraphRenderer {
         depthFormat: TextureFormat? = .depth32Float,
         beforeRender: (() throws -> Void)? = nil
     ) throws {
+        var backend = backend
         if backend.deviceEventHandler == nil {
             backend.deviceEventHandler = { event in
                 switch event {
                 case .willReset, .resetFailed:
-                    resetPipelineCache()
+                    Task { @MainActor in
+                        Self.resetPipelineCache()
+                    }
                 case .didReset:
                     break
                 }

--- a/Tests/SDLKitGraphicsTests/ComputeSamplerBindingTests.swift
+++ b/Tests/SDLKitGraphicsTests/ComputeSamplerBindingTests.swift
@@ -11,6 +11,8 @@ private final class SamplerTrackingBackend: RenderBackend {
     private var computeRequirements: [ComputePipelineHandle: Set<Int>] = [:]
     private(set) var lastBoundSamplers: [Int: SamplerDescriptor] = [:]
 
+    var deviceEventHandler: RenderBackendDeviceEventHandler?
+
     private init(baseWindow: SDLWindow, requiredSlots: Set<Int>) {
         self.window = baseWindow
         self.requiredSamplerSlots = requiredSlots

--- a/Tests/SDLKitGraphicsTests/PushConstantValidationTests.swift
+++ b/Tests/SDLKitGraphicsTests/PushConstantValidationTests.swift
@@ -10,6 +10,8 @@ private final class EnforcingBackend: RenderBackend {
     private var pipelineRequirements: [PipelineHandle: Int] = [:]
     private var computeRequirements: [ComputePipelineHandle: Int] = [:]
 
+    var deviceEventHandler: RenderBackendDeviceEventHandler?
+
     private init(baseWindow: SDLWindow, override: Int?) {
         self.window = baseWindow
         self.computeOverride = override

--- a/Tests/SDLKitTests/SceneGraphPushConstantTests.swift
+++ b/Tests/SDLKitTests/SceneGraphPushConstantTests.swift
@@ -20,6 +20,8 @@ private final class RecordingRenderBackend: RenderBackend {
     private var pipelines: [PipelineHandle: GraphicsPipelineDescriptor] = [:]
     private var frameActive = false
 
+    var deviceEventHandler: RenderBackendDeviceEventHandler?
+
     var drawCallCount = 0
     var lastBindings: BindingSet?
     var lastPushConstants: [Float]?


### PR DESCRIPTION
## Summary
- add device-lost handling to the JSON agent's error serialization
- ensure the scene graph renderer's device reset handler updates the pipeline cache on the main actor
- provide the test render backends with the new deviceEventHandler hook

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68de3486b45c8333a2f0b78d29c2feae