### PR TITLE
Enforce Vulkan SDK requirement on Linux

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,12 @@
 import PackageDescription
 import Foundation
 
+#if os(Linux)
+let isLinux = true
+#else
+let isLinux = false
+#endif
+
 let env = ProcessInfo.processInfo.environment
 let useYams = (env["SDLKIT_NO_YAMS"] ?? "0") != "1"
 
@@ -33,6 +39,12 @@ let hasSDL3 = shouldUseSystemPackage("sdl3")
 let hasSDL3Image = shouldUseSystemPackage("sdl3-image")
 let hasSDL3TTF = shouldUseSystemPackage("sdl3-ttf")
 let hasVulkan = pkgConfigExists("vulkan")
+
+if isLinux && !hasVulkan {
+    fatalError("""
+    Vulkan development files are required to build SDLKit on Linux. Install the Vulkan SDK (headers, loader, and validation layers) via your distribution's package manager—for example `sudo apt install libvulkan-dev vulkan-validationlayers` on Debian/Ubuntu—then re-run the build.
+    """)
+}
 
 let package = Package(
     name: "SDLKit",
@@ -128,7 +140,7 @@ let package = Package(
                         "CSDL3",
                         .target(name: "CSDL3IMAGE", condition: .when(platforms: [.macOS, .linux]))
                     ]
-                    if hasVulkan {
+                    if isLinux {
                         deps.append(.target(name: "CVulkan", condition: .when(platforms: [.linux])))
                     }
                     if useYams { deps.append(.product(name: "Yams", package: "Yams")) }
@@ -168,7 +180,7 @@ let package = Package(
             )
         )
 
-        if hasVulkan {
+        if isLinux {
             targets.append(
                 .systemLibrary(
                     name: "CVulkan",
@@ -180,7 +192,7 @@ let package = Package(
             )
         }
 
-        if hasVulkan {
+        if isLinux {
             targets.append(
                 .target(
                     name: "VulkanMinimal",
@@ -222,7 +234,7 @@ let package = Package(
                         "SDLKit",
                         .target(name: "SDLKitTTF", condition: .when(platforms: [.macOS, .linux]))
                     ]
-                    if hasVulkan {
+                    if isLinux {
                         deps.append(.target(name: "VulkanMinimal", condition: .when(platforms: [.linux])))
                     }
                     return deps

--- a/Sources/SDLKit/Graphics/Vulkan/VulkanRenderBackend.swift
+++ b/Sources/SDLKit/Graphics/Vulkan/VulkanRenderBackend.swift
@@ -10,6 +10,10 @@ import VulkanMinimal
 import CVulkan
 #endif
 
+private let missingVulkanDependencyMessage = "Vulkan headers and the loader were not detected. Install the Vulkan SDK for your distribution (see docs/install.md) and re-run the build."
+
+#if canImport(CVulkan)
+
 @MainActor
 public final class VulkanRenderBackend: RenderBackend, GoldenImageCapturable {
     private static let descriptorSetBudgetPerFrame = 64
@@ -199,6 +203,8 @@ public final class VulkanRenderBackend: RenderBackend, GoldenImageCapturable {
         try initializeVulkan()
         #if canImport(CVulkan)
         try initializeDeviceAndQueues()
+        #else
+        throw AgentError.missingDependency(missingVulkanDependencyMessage)
         #endif
     }
 
@@ -3644,4 +3650,125 @@ public final class VulkanRenderBackend: RenderBackend, GoldenImageCapturable {
     }
     #endif
 }
+#else
+@MainActor
+public final class VulkanRenderBackend: RenderBackend, GoldenImageCapturable {
+    public var deviceEventHandler: RenderBackendDeviceEventHandler?
+
+    public required init(window: SDLWindow) throws {
+        throw AgentError.missingDependency(missingVulkanDependencyMessage)
+    }
+
+    private func missingDependencyError() -> AgentError {
+        AgentError.missingDependency(missingVulkanDependencyMessage)
+    }
+
+    private func missingDependencyTrap() -> Never {
+        fatalError(missingVulkanDependencyMessage)
+    }
+
+    public func beginFrame() throws {
+        throw missingDependencyError()
+    }
+
+    public func endFrame() throws {
+        throw missingDependencyError()
+    }
+
+    public func resize(width: Int, height: Int) throws {
+        throw missingDependencyError()
+    }
+
+    public func waitGPU() throws {
+        throw missingDependencyError()
+    }
+
+    public func createBuffer(bytes: UnsafeRawPointer?, length: Int, usage: BufferUsage) throws -> BufferHandle {
+        throw missingDependencyError()
+    }
+
+    public func requestCapture() {
+        missingDependencyTrap()
+    }
+
+    public func takeCaptureHash() throws -> String {
+        throw missingDependencyError()
+    }
+
+    public func takeValidationMessages() -> [String] {
+        missingDependencyTrap()
+    }
+
+    static func drainCapturedValidationMessages() -> [String] {
+        fatalError(missingVulkanDependencyMessage)
+    }
+
+    public func createTexture(descriptor: TextureDescriptor, initialData: TextureInitialData?) throws -> TextureHandle {
+        throw missingDependencyError()
+    }
+
+    public func createSampler(descriptor: SamplerDescriptor) throws -> SamplerHandle {
+        throw missingDependencyError()
+    }
+
+    public func destroy(_ handle: ResourceHandle) {
+        missingDependencyTrap()
+    }
+
+    public func registerMesh(vertexBuffer: BufferHandle,
+                             vertexCount: Int,
+                             indexBuffer: BufferHandle?,
+                             indexCount: Int,
+                             indexFormat: IndexFormat) throws -> MeshHandle {
+        throw missingDependencyError()
+    }
+
+    public func makePipeline(_ desc: GraphicsPipelineDescriptor) throws -> PipelineHandle {
+        throw missingDependencyError()
+    }
+
+    public func draw(mesh: MeshHandle, pipeline: PipelineHandle, bindings: BindingSet, transform: float4x4) throws {
+        throw missingDependencyError()
+    }
+
+    public func makeComputePipeline(_ desc: ComputePipelineDescriptor) throws -> ComputePipelineHandle {
+        throw missingDependencyError()
+    }
+
+    public func dispatchCompute(_ pipeline: ComputePipelineHandle, groupsX: Int, groupsY: Int, groupsZ: Int, bindings: BindingSet) throws {
+        throw missingDependencyError()
+    }
+
+    internal struct DebugResourceInventory: Equatable {
+        let bufferCount: Int
+        let textureCount: Int
+        let samplerCount: Int
+        let meshCount: Int
+        let graphicsPipelineCount: Int
+        let computePipelineCount: Int
+    }
+
+    internal func debugResourceInventory() -> DebugResourceInventory {
+        missingDependencyTrap()
+    }
+
+#if DEBUG
+    public func debugSimulateDeviceLoss() {
+        missingDependencyTrap()
+    }
+
+    internal func debugTextureDescriptor(for handle: TextureHandle) -> TextureDescriptor? {
+        missingDependencyTrap()
+    }
+
+    internal func debugBufferLength(for handle: BufferHandle) -> Int? {
+        missingDependencyTrap()
+    }
+
+    internal func debugTextureCount() -> Int {
+        missingDependencyTrap()
+    }
+#endif
+}
+#endif
 #endif

--- a/docs/install.md
+++ b/docs/install.md
@@ -35,6 +35,28 @@ sudo apt-get install -y libsdl3-dev
 
 Alternatively, build and install the fork manually, then export `PKG_CONFIG_PATH` so `pkg-config` finds the resulting `.pc` file.
 
+Install the Vulkan SDK packages so SwiftPM can link the `CVulkan` module:
+
+```bash
+sudo apt-get install -y libvulkan-dev vulkan-headers vulkan-validationlayers vulkan-tools
+```
+
+This brings in the loader, headers, and validation layers used by SDLKit’s Vulkan backend.
+
+### Linux (Fedora/RHEL)
+
+```bash
+sudo dnf install -y vulkan-devel vulkan-headers vulkan-validation-layers vulkan-tools
+```
+
+### Linux (Arch/Manjaro)
+
+```bash
+sudo pacman -S --needed vulkan-headers vulkan-icd-loader vulkan-validation-layers vulkan-tools
+```
+
+After installation, confirm `pkg-config --exists vulkan` succeeds; SDLKit’s manifest now fails fast when these packages are missing.
+
 ### Windows
 
 Install SDL3 via vcpkg:


### PR DESCRIPTION
## Summary
- require the Vulkan SDK on Linux builds by hard-failing Package.swift when pkg-config cannot locate vulkan and always wiring the CVulkan/VulkanMinimal targets
- replace the Vulkan backend's stub fallback with an explicit missing-dependency error path when the Vulkan SDK is absent
- document package manager commands for installing the Vulkan SDK on Debian/Ubuntu, Fedora/RHEL, and Arch-based distributions

## Testing
- not run (Vulkan SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68de45aa4bc48333aa917e55329c33f9