### PR TITLE
Add Vulkan validation setup to Linux CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,23 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: swift:6.1-jammy
+      options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Install Vulkan SDK components
+        run: |
+          set -euo pipefail
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            libvulkan1 \
+            libvulkan-dev \
+            vulkan-utils \
+            vulkan-validationlayers \
+            spirv-tools \
+            glslang-tools
+          rm -rf /var/lib/apt/lists/*
 
       # No SDL provisioning needed for headless tests
       - name: Prepare build env (headless)
@@ -51,15 +65,20 @@ jobs:
           SDLKIT_GUI_ENABLED: 'false'
           SDLKIT_VK_VALIDATION_CAPTURE: '1'
           SDLKIT_VK_VALIDATION: '1'
+          VK_INSTANCE_LAYERS: VK_LAYER_KHRONOS_validation
         run: |
-          set -e
+          set -euo pipefail
           swift build -v -Xswiftc -DHEADLESS_CI
+          log_dir="${{ runner.temp }}/vulkan-validation"
+          mkdir -p "$log_dir"
+          test_log="$log_dir/linux-swift-test.log"
+          : > "$test_log"
           attempt=1
           max_attempts=3
           backoff=5
           while [ $attempt -le $max_attempts ]; do
-            echo "Linux test attempt $attempt/$max_attempts"
-            if swift test -v -Xswiftc -DHEADLESS_CI; then
+            echo "Linux test attempt $attempt/$max_attempts" | tee -a "$test_log"
+            if swift test -v -Xswiftc -DHEADLESS_CI 2>&1 | tee -a "$test_log"; then
               break
             fi
             if [ $attempt -eq $max_attempts ]; then
@@ -69,6 +88,13 @@ jobs:
             sleep $((backoff * attempt))
             attempt=$((attempt + 1))
           done
+
+      - name: Upload Vulkan validation logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-vulkan-validation-logs
+          path: ${{ runner.temp }}/vulkan-validation
 
   windows:
     runs-on: windows-2022

--- a/Tests/SDLKitTests/VulkanValidationCaptureObserver.swift
+++ b/Tests/SDLKitTests/VulkanValidationCaptureObserver.swift
@@ -17,7 +17,7 @@ private final class VulkanValidationCaptureObserver: NSObject, XCTestObservation
         guard messages.isEmpty else {
             let joined = messages.joined(separator: "\n")
             fputs("Vulkan validation warnings captured during tests:\n\(joined)\n", stderr)
-            fatalError("Vulkan validation warnings detected")
+            fatalError("Vulkan validation warnings detected:\n\(joined)")
         }
     }
 }


### PR DESCRIPTION
## Summary
- install the Vulkan loader, validation layers, and SPIR-V tooling in the Linux workflow container
- run Linux tests with the Khronos validation layer enabled and capture the full log output
- upload the Vulkan validation logs as artifacts and include validation details in fatal errors
- run the Linux CI container as root so Vulkan development packages can be installed successfully

## Testing
- swift test -Xswiftc -DHEADLESS_CI *(fails locally because Vulkan development headers are missing in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68de48b0e2648333a64dd7ecdc61b0b8