### PR TITLE
Add regression harness artifacts to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-shader-
 
+      - name: Prepare regression artifact directory
+        run: |
+          set -euo pipefail
+          harness_root="${RUNNER_TEMP}/sdlkit-golden/linux"
+          mkdir -p "$harness_root"
+          echo "SDLKIT_GOLDEN_ARTIFACT_DIR=$harness_root" >> "$GITHUB_ENV"
+
       - name: Build shader bundle (best effort)
         run: |
           python3 Scripts/ShaderBuild/build-shaders.py "$PWD" .build/shader-cache
@@ -96,6 +103,25 @@ jobs:
           name: linux-vulkan-validation-logs
           path: ${{ runner.temp }}/vulkan-validation
 
+      - name: Run regression harness (Vulkan)
+        env:
+          SDLKIT_GOLDEN: '1'
+          SDLKIT_GUI_ENABLED: 'false'
+          SDLKIT_VK_VALIDATION_CAPTURE: '1'
+          SDLKIT_VK_VALIDATION: '1'
+          VK_INSTANCE_LAYERS: VK_LAYER_KHRONOS_validation
+        run: |
+          set -euo pipefail
+          swift test --skip-build --filter BackendHarnessTests -Xswiftc -DHEADLESS_CI
+
+      - name: Upload regression harness artifacts (Vulkan)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-golden-artifacts
+          path: ${{ env.SDLKIT_GOLDEN_ARTIFACT_DIR }}
+          if-no-files-found: ignore
+
   windows:
     runs-on: windows-2022
     steps:
@@ -106,6 +132,13 @@ jobs:
         uses: swift-actions/setup-swift@v1
         with:
           swift-version: '6.0.2'
+
+      - name: Prepare regression artifact directory
+        shell: pwsh
+        run: |
+          $dir = Join-Path $env:RUNNER_TEMP 'sdlkit-golden\windows'
+          New-Item -ItemType Directory -Force -Path $dir | Out-Null
+          "SDLKIT_GOLDEN_ARTIFACT_DIR=$dir" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Build and test (with retry)
         shell: pwsh
@@ -131,3 +164,64 @@ jobs:
             }
             $attempt++
           }
+
+      - name: Run regression harness (D3D12)
+        shell: pwsh
+        env:
+          SDLKIT_GOLDEN: '1'
+          SDLKIT_GUI_ENABLED: 'false'
+        run: |
+          $ErrorActionPreference = 'Stop'
+          swift test --skip-build --filter BackendHarnessTests -Xswiftc -DHEADLESS_CI
+
+      - name: Upload regression harness artifacts (D3D12)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-golden-artifacts
+          path: ${{ env.SDLKIT_GOLDEN_ARTIFACT_DIR }}
+          if-no-files-found: ignore
+
+  macos:
+    runs-on: macos-13
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install SDL2
+        run: brew install sdl2
+
+      - name: Prepare regression artifact directory
+        run: |
+          set -euo pipefail
+          harness_root="${RUNNER_TEMP}/sdlkit-golden/macos"
+          mkdir -p "$harness_root"
+          echo "SDLKIT_GOLDEN_ARTIFACT_DIR=$harness_root" >> "$GITHUB_ENV"
+
+      - name: Build
+        run: |
+          set -euo pipefail
+          swift build -v -Xswiftc -DHEADLESS_CI
+
+      - name: Run tests
+        env:
+          SDLKIT_GUI_ENABLED: 'false'
+        run: |
+          set -euo pipefail
+          swift test -v -Xswiftc -DHEADLESS_CI
+
+      - name: Run regression harness (Metal)
+        env:
+          SDLKIT_GOLDEN: '1'
+          SDLKIT_GUI_ENABLED: 'false'
+        run: |
+          set -euo pipefail
+          swift test --skip-build --filter BackendHarnessTests -Xswiftc -DHEADLESS_CI
+
+      - name: Upload regression harness artifacts (Metal)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-golden-artifacts
+          path: ${{ env.SDLKIT_GOLDEN_ARTIFACT_DIR }}
+          if-no-files-found: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,8 @@ public protocol ComputeScheduler {
 
 ## 6) Milestones & Cross‑Agent Acceptance
 
+> **Quality Gate:** The RenderBackend regression harness (golden image + compute suite) must pass on Metal, D3D12, and Vulkan before closing milestones **M1–M5**. CI runs the harness on each platform leg and publishes capture hashes/images for review when a failure occurs.
+
 **M0 — C Shim & Windowing**
 - Shim exposes: `CAMetalLayer`, `HWND`, `VkSurfaceKHR`. Minimal sample retrieves each and logs success.
 - Acceptance: sample runs on each platform; correct handle types; no crashes.


### PR DESCRIPTION
## Summary
- add GoldenImageCapture payload retrieval across all render backends to expose capture bytes for tooling
- extend the regression harness to dump per-test images/hashes and emit summaries for artifact review
- run the harness on every CI leg (macOS/Metal, Windows/D3D12, Linux/Vulkan), uploading artifacts and documenting the milestone gate

## Testing
- swift build *(fails: Vulkan development files are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68de7b43c5ec8333ac62e6dcd2cbcc86